### PR TITLE
Switch to Zeitwerk

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     bulma-phlex (0.4.0)
       phlex (>= 2.0.2)
+      zeitwerk (~> 2.7)
 
 GEM
   remote: https://rubygems.org/

--- a/bulma-phlex.gemspec
+++ b/bulma-phlex.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "phlex", ">= 2.0.2"
+  spec.add_dependency "zeitwerk", "~> 2.7"
 
   spec.add_development_dependency "actionpack"
   spec.add_development_dependency "actionview"

--- a/lib/bulma-phlex.rb
+++ b/lib/bulma-phlex.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
-require "phlex"
 require "bulma_phlex/version"
+require "zeitwerk"
+require "phlex"
 
-require "components/bulma"
-require "components/bulma/base"
-require "components/bulma/card"
-require "components/bulma/dropdown"
-require "components/bulma/level"
-require "components/bulma/navigation_bar_dropdown"
-require "components/bulma/navigation_bar"
-require "components/bulma/pagination"
-require "components/bulma/table"
-require "components/bulma/tabs"
-require "components/bulma/tab_components/content"
-require "components/bulma/tab_components/tab"
+loader = Zeitwerk::Loader.new
+loader.tag = "bulma-phlex"
+loader.push_dir(File.dirname(__FILE__))
+loader.ignore(__FILE__)
+loader.setup


### PR DESCRIPTION
This does not use the `for_gem` method because the phlex components are not under the gem namespace (`Bulma::Phlex`), but instead under the Phlex-friendly `Components::Bulma`.