### PR TITLE
Eliminate load order dependency for phlex-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ Bulma::Card() do |card|
 end
 ```
 
+#### Rails Feature: Turbo Frame Content
+
+When the `turbo-rails` and `phlex-rails` gems are installed, the Card component also provides method `turbo_frame_content`, which allows the content to be deferred to a turbo frame. The method accepts the same parameters as [the Turbo Rails helper method `turbo_frame_tag`](https://github.com/hotwired/turbo-rails?tab=readme-ov-file#decompose-with-turbo-frames), with the addition of the following two attributes:
+
+- pending_message (default: "Loading...")
+- pending_icon (default: "fas fa-spinner fa-pulse")
+
+```ruby
+Bulma::Card() do |card|
+  card.head("Product Info")
+  card.turbo_frame_content("product", src: product_path(@product), pending_message: "Loading product...")
+end
+```
+
+
 ### Dropdown
 
 The [Dropdown](https://bulma.io/documentation/components/dropdown/) component provides a flexible dropdown menu for navigation or actions. It supports both click-to-toggle (default, requires a Stimulus controller) and hoverable modes, as well as alignment and icon customization.

--- a/lib/bulma-phlex.rb
+++ b/lib/bulma-phlex.rb
@@ -9,3 +9,5 @@ loader.tag = "bulma-phlex"
 loader.push_dir(File.dirname(__FILE__))
 loader.ignore(__FILE__)
 loader.setup
+
+require "bulma_phlex/railtie" if defined?(Rails)

--- a/lib/bulma_phlex/rails/card_helper.rb
+++ b/lib/bulma_phlex/rails/card_helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  module Rails
+    # # Card Helper
+    #
+    # This module provides method `turbo_frame_content` to create a card with a turbo frame as its content.
+    module CardHelper
+      extend ActiveSupport::Concern
+
+      included do
+        include Phlex::Rails::Helpers::TurboFrameTag
+      end
+
+      # Renders a Bulma-styled card with a Turbo Frame as its content. This uses the same signatures as
+      # `turbo_frame_tag`, with the addition of two optional attributes: `pending_message` and `pending_icon`.
+      #
+      # The two pending attributes have the following defaults:
+      # - pending_message: "Loading..."
+      # - pending_icon: "fas fa-spinner fa-pulse"
+      def turbo_frame_content(*ids, src: nil, target: nil, **attributes)
+        pending_message = attributes.delete(:pending_message) || "Loading..."
+        pending_icon = attributes.delete(:pending_icon) || "fas fa-spinner fa-pulse"
+
+        content do
+          turbo_frame_tag ids, src: src, target: target, **attributes do
+            span(class: "icon") { i class: pending_icon }
+            span { plain pending_message }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bulma_phlex/railtie.rb
+++ b/lib/bulma_phlex/railtie.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  # # Railtie for BulmaPhlex
+  #
+  # This Railtie adds Rails-specific features to the BulmaPhlex library.
+  class Railtie < ::Rails::Railtie
+    initializer "bulma_phlex" do
+      ActiveSupport.on_load(:action_view) do
+        Components::Bulma::Card.include(BulmaPhlex::Rails::CardHelper) if defined?(Phlex::Rails) && defined?(Turbo)
+      end
+    end
+  end
+end

--- a/lib/components/bulma/card.rb
+++ b/lib/components/bulma/card.rb
@@ -19,6 +19,11 @@ module Components
     # end
     # ```
     #
+    # ## Rails Feature: Turbo Frame Content
+    #
+    # If the project includes Rails and the Phlex::Rails gem, the `BulmaPhlex::Rails::CardHelper` module
+    # provides a `turbo_frame_content` method to create a card with a turbo frame
+    # as its content. This allows for dynamic loading of card content.
     class Card < Components::Bulma::Base
       def view_template(&)
         div(class: "card", &)
@@ -33,24 +38,6 @@ module Components
       def content(&)
         div(class: "card-content") do
           div(class: "content", &)
-        end
-      end
-
-      if defined?(Phlex::Rails)
-        include Phlex::Rails::Helpers::TurboFrameTag
-
-        # this copies the signature of the turbo_frame_tag helper,
-        # with the addition of a pending_message attribute
-        def turbo_frame_content(*ids, src: nil, target: nil, **attributes)
-          pending_message = attributes.delete(:pending_message) || "Loading..."
-          pending_icon = attributes.delete(:pending_icon) || "fas fa-spinner fa-pulse"
-
-          content do
-            turbo_frame_tag ids, src: src, target: target, **attributes do
-              span(class: "icon") { i class: pending_icon }
-              span { plain pending_message }
-            end
-          end
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
-# Suppress method redefined warnings before requiring libraries
-original_verbose = $VERBOSE
-$VERBOSE = nil
+# Suppress only Phlex-related 'method redefined' warnings
+module Warning
+  def self.warn(msg)
+    return if msg =~ %r{gems/phlex}i
+
+    super
+  end
+end
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "bulma-phlex"
@@ -10,9 +15,6 @@ require "minitest/autorun"
 require "nokogiri"
 require "active_support/test_case"
 require "action_view/test_case"
-
-# Restore original warning level after libraries are loaded
-$VERBOSE = original_verbose
 
 module TagOutputAssertions
   include ActionView::TestCase::DomAssertions


### PR DESCRIPTION
Checking for Phlex::Rails in the code introduced a load order dependency: if the phlex-rails gem was below this gem in the Gemfile, it would not be seen and the additional functionality would not be included.

This change checks for Rails at startup, then defers checks for Phlex::Rails (and Turbo) to an initializer in a Railtie.

Resolves #1 

---

The Railtie and the mixin also provide a pattern for additional Rails-only features.