### PR TITLE
Table Enhnacements: Styles plus amount, date, and conditional icon columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,20 +186,33 @@ The [Table](https://bulma.io/documentation/elements/table/) component provides a
 ```ruby
 users = User.all
 
-Bulma::Table(users) do |table|
+Bulma::Table(users, fullwidth: true, hoverable: true) do |table|
   table.column "Name" do |user|
     user.full_name
   end
 
-  table.column "Email" do |user|
-    user.email
-  end
+  # use the symbol-to-proc shortcut!
+  table.column "Email", &:email
 
   table.column "Actions" do |user|
     link_to "Edit", edit_user_path(user), class: "button is-small"
   end
 end
 ```
+
+**Constructor Keyword Arguments:**
+
+- `rows`: the data for the table as an enumerable (anything that responds to `each`)
+- `id`: the Id for the table element (defaults to "table")
+- `bordered`: adds the `is-bordered` class (boolean, defaults to false)
+- `striped`: adds the `is-striped` class (boolean, defaults to false)
+- `narrow`: adds the `is-narrow` class (boolean, defaults to false)
+- `hoverable`: adds the `is-hoverable` class (boolean, defaults to false)
+- `fullwidth`: adds the `is-fullwidth` class (boolean, defaults to false)
+
+**Arguments for `column` Method:**
+
+The `column` method takes the column name and any html attributes to be assigned to the table cell element. The block will be called with the row as the parameter.
 
 ### Tabs
 

--- a/README.md
+++ b/README.md
@@ -221,10 +221,11 @@ Instead of calling `column`, you can also invoke the following methods to add am
 **Arguments for `amount_column` (Rails only):**
 
 - name: content for the `th` element
-- `format` (keyword): the formatting options (will be passed to [Rails helper number_to_currency](https://api.rubyonrails.org/classes/ActiveSupport/NumberHelper.html#method-i-number_to_currency), uses Rails default)
+- `currency` (keyword): options that will be passed to [Rails helper number_to_currency](https://api.rubyonrails.org/classes/ActiveSupport/NumberHelper.html#method-i-number_to_currency, uses Rails defaults)
 
 ```ruby
   table.amount_column("Payment Amount") { |row| row.payment_amount }
+  table.amount_column("Total", currency: { unit: "€" }, class: "is-bold", &:total)
 ```
 
 **Arguments for `date_column`:**

--- a/README.md
+++ b/README.md
@@ -214,6 +214,62 @@ end
 
 The `column` method takes the column name and any html attributes to be assigned to the table cell element. The block will be called with the row as the parameter.
 
+#### Additional Column Types
+
+Instead of calling `column`, you can also invoke the following methods to add amount, date, and icon columns:
+
+**Arguments for `amount_column` (Rails only):**
+
+- name: content for the `th` element
+- `format` (keyword): the formatting options (will be passed to [Rails helper number_to_currency](https://api.rubyonrails.org/classes/ActiveSupport/NumberHelper.html#method-i-number_to_currency), uses Rails default)
+
+```ruby
+  table.amount_column("Payment Amount") { |row| row.payment_amount }
+```
+
+**Arguments for `date_column`:**
+
+- name: content for the `th` element
+- `format` (keyword): the formatting options (will be passed to `strftime`, defaults to "%Y-%m-%d")
+
+```ruby
+  table.date_column("Due Date", format: "%B %d, %Y") { |row| row.due_date }
+```
+
+**Arguments for `conditional_icon`:**
+
+The icon column is intended to show a boolean flag: a yes / no or an on / off. When the value is true the icon shows and when the value is false it does not.
+
+- name: content for the `th` element
+- `icon_class` (keyword): the icon to show (defaults to the Font Awesome check mark: "fas fa-check")
+ 
+```ruby
+  table.conditional_icon("Completed?", &:complete)
+  table.conditional_icon("Approved?", icon_class: "fas fa-thumbs-up") { |row| row.status == "Approved" }
+```
+
+#### Pagination
+
+If the table should be paginated, invoke method `paginate` with a block that will return a path given a page number.
+
+```ruby
+  table.paginate do |page_number|
+    products_path(page: { number: page_number })
+  end
+```
+
+In order to support pagination, the `rows` argument passed into the constructor must repond with integers to the following:
+
+- current_page
+- total_pages
+- per_page
+- total_count
+- previous_page (can be nil)
+- next_page (can be nil)
+
+This generates the [Bulma pagination](https://bulma.io/documentation/components/pagination/) component, providing navigation controls for paginated content.
+
+
 ### Tabs
 
 The [Tabs](https://bulma.io/documentation/components/tabs/) component provides a way to toggle between different content sections using tabbed navigation, with support for icons and active state management.

--- a/lib/bulma_phlex/rails/table_helper.rb
+++ b/lib/bulma_phlex/rails/table_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  module Rails
+    # # Table Helper
+    #
+    # This module provides method `amount_column` to create an amount column in a table.
+    module TableHelper
+      extend ActiveSupport::Concern
+
+      included do
+        include Phlex::Rails::Helpers::NumberToCurrency
+      end
+
+      def amount_column(header, currency: {}, **html_attributes, &content)
+        html_attributes[:class] = [html_attributes[:class], "has-text-right"].compact.join(" ")
+
+        column(header, **html_attributes) do |row|
+          number_to_currency(content.call(row), **currency)
+        end
+      end
+    end
+  end
+end

--- a/lib/bulma_phlex/railtie.rb
+++ b/lib/bulma_phlex/railtie.rb
@@ -7,7 +7,10 @@ module BulmaPhlex
   class Railtie < ::Rails::Railtie
     initializer "bulma_phlex" do
       ActiveSupport.on_load(:action_view) do
-        Components::Bulma::Card.include(BulmaPhlex::Rails::CardHelper) if defined?(Phlex::Rails) && defined?(Turbo)
+        if defined?(Phlex::Rails)
+          Components::Bulma::Card.include(BulmaPhlex::Rails::CardHelper) if defined?(Turbo)
+          Components::Bulma::Table.include(BulmaPhlex::Rails::TableHelper)
+        end
       end
     end
   end

--- a/lib/components/bulma/table.rb
+++ b/lib/components/bulma/table.rb
@@ -29,16 +29,16 @@ module Components
     # ```
     #
     class Table < Components::Bulma::Base
-      def initialize(rows, id = nil)
-        @id = id || id_from_array_or_arel(rows)
+      def initialize(rows, id_or_options = nil, **options)
         @rows = rows
+        @id, @table_class = parse_id_and_options(id_or_options, options, rows)
         @columns = []
       end
 
       def view_template(&)
         vanish(&)
 
-        table(id: @id, class: "table is-fullwidth") do
+        table(id: @id, class: @table_class) do
           thead do
             @columns.each do |column|
               table_header(column)
@@ -69,6 +69,18 @@ module Components
 
       private
 
+      def parse_id_and_options(id_or_options, options, rows)
+        if id_or_options.is_a?(String)
+          id = id_or_options
+          opts = options
+        else
+          opts = (id_or_options || {}).merge(options)
+          id = opts.delete(:id) || id_from_array_or_arel(rows)
+        end
+        table_class = "table #{parse_table_classes(opts)}"
+        [id, table_class]
+      end
+
       def id_from_array_or_arel(rows)
         if rows.respond_to? :model
           rows.model.model_name.plural
@@ -77,6 +89,14 @@ module Components
         else
           rows.first.model_name.plural
         end
+      end
+
+      def parse_table_classes(options)
+        options.slice(*%i[bordered striped narrow hoverable fullwidth])
+               .transform_keys { |key| "is-#{key}" }
+               .select { |_, value| value }
+               .keys
+               .join(" ")
       end
 
       # this derives a th class from the column html attributes

--- a/lib/components/bulma/table.rb
+++ b/lib/components/bulma/table.rb
@@ -63,6 +63,12 @@ module Components
         @columns << { header:, html_attributes:, content: }
       end
 
+      def date_column(header, format: "%Y-%m-%d", **html_attributes, &content)
+        column(header, **html_attributes) do |row|
+          content.call(row)&.strftime(format)
+        end
+      end
+
       def paginate(&path_builder)
         @path_builder = path_builder
       end
@@ -89,6 +95,8 @@ module Components
         else
           rows.first.model_name.plural
         end
+      rescue StandardError
+        "table"
       end
 
       def parse_table_classes(options)

--- a/lib/components/bulma/table.rb
+++ b/lib/components/bulma/table.rb
@@ -69,6 +69,14 @@ module Components
         end
       end
 
+      def conditional_icon(header, icon_class: "fas fa-check", **html_attributes, &content)
+        html_attributes[:class] = [html_attributes[:class], "has-text-centered"].compact.join(" ")
+
+        column(header, **html_attributes) do |row|
+          icon_span(icon_class) if content.call(row)
+        end
+      end
+
       def paginate(&path_builder)
         @path_builder = path_builder
       end

--- a/test/components/bulma/table_test.rb
+++ b/test/components/bulma/table_test.rb
@@ -128,5 +128,83 @@ module Components
         assert_html_includes format_html(raw_result), 'class="table is-bordered is-striped is-narrow"'
       end
     end
+
+    class TableDateColumnTest < Minitest::Test
+      include TagOutputAssertions
+
+      TestRecord = Data.define(:id, :name, :start_date)
+
+      def test_date_column_with_default_format
+        rows = [
+          TestRecord.new(id: 1, name: "Event 1", start_date: Time.new(2023, 10, 1)),
+          TestRecord.new(id: 2, name: "Event 2", start_date: Time.new(2023, 10, 2))
+        ]
+
+        component = Components::Bulma::Table.new(rows)
+
+        raw_result = component.call do |table|
+          table.date_column("Start Date", &:start_date)
+        end
+
+        result = format_html(raw_result)
+
+        assert_html_includes result, "<td>2023-10-01</td>"
+        assert_html_includes result, "<td>2023-10-02</td>"
+      end
+
+      def test_date_column_with_custom_format
+        rows = [
+          TestRecord.new(id: 1, name: "Event 1", start_date: Time.new(2023, 10, 1)),
+          TestRecord.new(id: 2, name: "Event 2", start_date: Time.new(2023, 10, 2))
+        ]
+
+        component = Components::Bulma::Table.new(rows)
+
+        raw_result = component.call do |table|
+          table.date_column("Start Date", format: "%d-%m-%Y", &:start_date)
+        end
+
+        result = format_html(raw_result)
+
+        assert_html_includes result, "<td>01-10-2023</td>"
+        assert_html_includes result, "<td>02-10-2023</td>"
+      end
+
+      def test_date_column_with_nil_value
+        rows = [
+          TestRecord.new(id: 1, name: "Event 1", start_date: nil),
+          TestRecord.new(id: 2, name: "Event 2", start_date: Time.new(2023, 10, 2))
+        ]
+
+        component = Components::Bulma::Table.new(rows)
+
+        raw_result = component.call do |table|
+          table.date_column("Start Date", &:start_date)
+        end
+
+        result = format_html(raw_result)
+
+        assert_html_includes result, "<td></td>" # Expect empty cell for nil date
+        assert_html_includes result, "<td>2023-10-02</td>"
+      end
+
+      def test_date_column_with_html_attributes
+        rows = [
+          TestRecord.new(id: 1, name: "Event 1", start_date: Time.new(2023, 10, 1)),
+          TestRecord.new(id: 2, name: "Event 2", start_date: Time.new(2023, 10, 2))
+        ]
+
+        component = Components::Bulma::Table.new(rows)
+
+        raw_result = component.call do |table|
+          table.date_column("Start Date", data: { custom: "go-bears" }, &:start_date)
+        end
+
+        result = format_html(raw_result)
+
+        assert_html_includes result, '<td data-custom="go-bears">2023-10-01</td>'
+        assert_html_includes result, '<td data-custom="go-bears">2023-10-02</td>'
+      end
+    end
   end
 end

--- a/test/components/bulma/table_test.rb
+++ b/test/components/bulma/table_test.rb
@@ -206,5 +206,53 @@ module Components
         assert_html_includes result, '<td data-custom="go-bears">2023-10-02</td>'
       end
     end
+
+    class TableConditionalIconTest < Minitest::Test
+      include TagOutputAssertions
+
+      TestRecord = Data.define(:id, :name, :active)
+
+      def test_header
+        rows = [TestRecord.new(id: 1, name: "Item 1", active: true)]
+        component = Components::Bulma::Table.new(rows)
+
+        raw_result = component.call do |table|
+          table.conditional_icon("Active", icon_class: "fas fa-check", &:active)
+        end
+        result = format_html(raw_result)
+
+        assert_html_includes result, '<th class="has-text-centered">Active</th>'
+      end
+
+      def test_conditional_icon_column_with_true
+        row = [TestRecord.new(id: 1, name: "Item 1", active: true)]
+        component = Components::Bulma::Table.new(row)
+
+        raw_result = component.call do |table|
+          table.conditional_icon("Active", icon_class: "fas fa-check", &:active)
+        end
+        result = format_html(raw_result)
+
+        assert_html_includes result, <<~HTML
+          <td class="has-text-centered">
+            <span class="icon">
+              <i class="fas fa-check"></i>
+            </span>
+          </td>
+        HTML
+      end
+
+      def test_conditional_icon_column_with_false
+        row = [TestRecord.new(id: 2, name: "Item 2", active: false)]
+        component = Components::Bulma::Table.new(row)
+
+        raw_result = component.call do |table|
+          table.conditional_icon("Active", icon_class: "fas fa-check", &:active)
+        end
+        result = format_html(raw_result)
+
+        assert_html_includes result, '<td class="has-text-centered"></td>'
+      end
+    end
   end
 end

--- a/test/components/bulma/table_test.rb
+++ b/test/components/bulma/table_test.rb
@@ -65,7 +65,7 @@ module Components
         refute_includes result, "<tr>"
       end
 
-      def test_renders_with_custom_id
+      def test_renders_with_string_id
         rows = [TestRecord.new(id: nil, name: "Test", email: nil)]
         component = Components::Bulma::Table.new(rows, "custom-table-id")
 
@@ -73,10 +73,59 @@ module Components
           table.column("Name", &:name)
         end
 
-        # Format the result for readable assertions and debugging
-        result = format_html(raw_result)
+        assert_html_includes format_html(raw_result), 'id="custom-table-id"'
+      end
 
-        assert_html_includes result, 'id="custom-table-id"'
+      def test_renders_with_id_option
+        rows = [TestRecord.new(id: nil, name: "Test", email: nil)]
+        component = Components::Bulma::Table.new(rows, id: "custom-table-id")
+        raw_result = component.call { |table| table.column("Name", &:name) }
+
+        assert_html_includes format_html(raw_result), 'id="custom-table-id"'
+      end
+
+      def test_bordered_table
+        rows = [TestRecord.new(id: nil, name: "Test", email: nil)]
+        component = Components::Bulma::Table.new(rows, bordered: true)
+        raw_result = component.call { |table| table.column("Name", &:name) }
+
+        assert_html_includes format_html(raw_result), 'class="table is-bordered"'
+      end
+
+      def test_striped_table
+        component = Components::Bulma::Table.new([], striped: true)
+        raw_result = component.call { |table| table.column("Name", &:name) }
+
+        assert_html_includes format_html(raw_result), 'class="table is-striped"'
+      end
+
+      def test_narrow_table
+        component = Components::Bulma::Table.new([], narrow: true)
+        raw_result = component.call { |table| table.column("Name", &:name) }
+
+        assert_html_includes format_html(raw_result), 'class="table is-narrow"'
+      end
+
+      def test_hoverable_table
+        component = Components::Bulma::Table.new([], hoverable: true)
+        raw_result = component.call { |table| table.column("Name", &:name) }
+
+        assert_html_includes format_html(raw_result), 'class="table is-hoverable"'
+      end
+
+      def test_fullwidth_table
+        component = Components::Bulma::Table.new([], fullwidth: true)
+        raw_result = component.call { |table| table.column("Name", &:name) }
+
+        assert_html_includes format_html(raw_result), 'class="table is-fullwidth"'
+      end
+
+      def test_combined_classes
+        rows = [TestRecord.new(id: nil, name: "Test", email: nil)]
+        component = Components::Bulma::Table.new(rows, bordered: true, striped: true, narrow: true)
+        raw_result = component.call { |table| table.column("Name", &:name) }
+
+        assert_html_includes format_html(raw_result), 'class="table is-bordered is-striped is-narrow"'
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,8 @@ module TagOutputAssertions
     formatted_html = format_html(html)
     formatted_substring = format_html(substring)
 
+    return assert(true) if squash_html_whitespace(formatted_html).include?(squash_html_whitespace(formatted_substring))
+
     msg = message(msg) do
       "Expected HTML to include substring.\n\n" \
         "HTML:\n#{formatted_html}\n\n" \
@@ -55,5 +57,10 @@ module TagOutputAssertions
   rescue StandardError => e
     puts "Error formatting HTML: #{e.message}"
     html
+  end
+
+  def squash_html_whitespace(str)
+    # Replace whitespace between tags as well as leading/trailing whitespace
+    str.gsub(/>\s+</, "><").strip
   end
 end


### PR DESCRIPTION
This enhances the Table component to allow the following five options for styling Bulma tables:
- bordered
- striped
- narrow
- hoverable
- fullwidth

Each should be passed in with a boolean flag such as the following:

    Bulma::Table.new(rows, bordered: true)

Additionally, the following methods have been added for amount, date, and conditional icon columns:
- amount_column
- date_column
- conditional_icon

The `amount_column` method uses the Rails helper `number_to_currency` and as such is only available when Rails is present.