### PR TITLE
Do not assume classes on Navigation Bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ end
 The [NavigationBar](https://bulma.io/documentation/components/navbar/) component provides a responsive navigation header with support for branding, navigation links, and dropdown menus.
 
 ```ruby
-Bulma::NavigationBar() do |navbar|
+Bulma::NavigationBar(classes: "is-primary") do |navbar|
   navbar.brand_item "My App", "/"
 
   navbar.left do |menu|
@@ -175,6 +175,10 @@ Bulma::NavigationBar() do |navbar|
   end
 end
 ```
+
+**Constructor Keyword Arguments:**
+
+- `classes`: Additional classes to be added to the `nav` element, such as "is-primary" or "has-shadow".
 
 ### Pagination
 

--- a/lib/components/bulma/navigation_bar.rb
+++ b/lib/components/bulma/navigation_bar.rb
@@ -36,7 +36,8 @@ module Components
     # ```
     #
     class NavigationBar < Components::Bulma::Base
-      def initialize
+      def initialize(classes: "")
+        @classes = classes
         @brand = []
         @left = []
         @right = []
@@ -45,7 +46,7 @@ module Components
       def view_template(&)
         vanish(&)
 
-        nav(class: "navbar is-light block",
+        nav(class: "navbar #{@classes}".rstrip,
             role: "navigation",
             aria_label: "main navigation",
             data: { controller: "bulma--navigation-bar" }) do

--- a/test/components/bulma/navigation_bar_test.rb
+++ b/test/components/bulma/navigation_bar_test.rb
@@ -26,7 +26,7 @@ module Components
       end
 
       def test_renders_with_left_and_right_menus
-        component = Components::Bulma::NavigationBar.new
+        component = Components::Bulma::NavigationBar.new(classes: "is-light block")
 
         result = component.call do |navbar|
           navbar.brand do


### PR DESCRIPTION
The NavigationBar component previously added classes is-light and block to the nav element (alongside the navbar class). Now the classes can be specified via the `classes` keyword argument in the constructor.

To keep the existing behavior, use the following constructor argument:

    Components::Bulma::NavigationBar.new(classes: "is-light block")