### PR TITLE
Make container optional on Navigation Bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ end
 **Constructor Keyword Arguments:**
 
 - `classes`: Additional classes to be added to the `nav` element, such as "is-primary" or "has-shadow".
+- `container`: When true, wraps the content in a Bulma container. To set a constraint, such as "is-max-desktop", pass that string instead of true. (defaults to false)
+
+> [!NOTE]  
+> Adding a container will limit the width of the Navigation Bar content according to Bulma's container rules. The background color of the navbar will still span the full width of the viewport.
 
 ### Pagination
 

--- a/lib/components/bulma/navigation_bar.rb
+++ b/lib/components/bulma/navigation_bar.rb
@@ -36,7 +36,8 @@ module Components
     # ```
     #
     class NavigationBar < Components::Bulma::Base
-      def initialize(classes: "")
+      def initialize(container: false, classes: "")
+        @container = container
         @classes = classes
         @brand = []
         @left = []
@@ -50,7 +51,7 @@ module Components
             role: "navigation",
             aria_label: "main navigation",
             data: { controller: "bulma--navigation-bar" }) do
-          div(class: "container") do
+          optional_container do
             div(class: "navbar-brand") do
               @brand.each(&:call)
 
@@ -90,6 +91,17 @@ module Components
 
       def right(&block)
         @right << block
+      end
+
+      private
+
+      def optional_container(&)
+        if @container
+          constraint = @container if @container.is_a?(String) || @container.is_a?(Symbol)
+          div(class: "container #{constraint}".rstrip, &)
+        else
+          yield
+        end
       end
     end
   end

--- a/test/components/bulma/navigation_bar_test.rb
+++ b/test/components/bulma/navigation_bar_test.rb
@@ -43,6 +43,40 @@ module Components
 
         expected_structure = <<~HTML
           <nav class="navbar is-light block" role="navigation" aria-label="main navigation" data-controller="bulma--navigation-bar">
+            <div class="navbar-brand">
+              <a href="/" class="navbar-item">Brand</a>
+              <a class="navbar-burger" role="button" aria-label="menu" aria-expanded="false" data-action="bulma--navigation-bar#toggle" data-bulma--navigation-bar-target="burger">
+                <span aria-hidden="true"></span>
+                <span aria-hidden="true"></span>
+                <span aria-hidden="true"></span>
+                <span aria-hidden="true"></span>
+              </a>
+            </div>
+            <div class="navbar-menu" data-bulma--navigation-bar-target="menu">
+              <div class="navbar-start">
+                <a href="/home" class="navbar-item">Home</a>
+              </div>
+              <div class="navbar-end">
+                <a href="/login" class="navbar-item">Login</a>
+              </div>
+            </div>
+          </nav>
+        HTML
+
+        assert_dom_equal expected_structure, result
+      end
+
+      def test_renders_with_container
+        component = Components::Bulma::NavigationBar.new(container: true)
+
+        result = component.call do |navbar|
+          navbar.brand do
+            navbar.a(href: "/", class: "navbar-item") { "Brand" }
+          end
+        end
+
+        expected_structure = <<~HTML
+          <nav class="navbar" role="navigation" aria-label="main navigation" data-controller="bulma--navigation-bar">
             <div class="container">
               <div class="navbar-brand">
                 <a href="/" class="navbar-item">Brand</a>
@@ -55,10 +89,8 @@ module Components
               </div>
               <div class="navbar-menu" data-bulma--navigation-bar-target="menu">
                 <div class="navbar-start">
-                  <a href="/home" class="navbar-item">Home</a>
                 </div>
                 <div class="navbar-end">
-                  <a href="/login" class="navbar-item">Login</a>
                 </div>
               </div>
             </div>
@@ -66,6 +98,18 @@ module Components
         HTML
 
         assert_dom_equal expected_structure, result
+      end
+
+      def test_renders_container_with_constraint
+        component = Components::Bulma::NavigationBar.new(container: "is-max-desktop")
+
+        result = component.call do |navbar|
+          navbar.brand do
+            navbar.a(href: "/", class: "navbar-item") { "Brand" }
+          end
+        end
+
+        assert_html_includes format_html(result), '<div class="container is-max-desktop">'
       end
     end
   end


### PR DESCRIPTION
This changes the container around the navigation bar content to optional, with the default of false. To keep the same behavior, invoke it with `container: true`.