### PR TITLE
Release 0.7.0: Navigation Bar Changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bulma-phlex (0.6.0)
+    bulma-phlex (0.7.0)
       phlex (>= 2.0.2)
 
 GEM

--- a/lib/bulma_phlex/version.rb
+++ b/lib/bulma_phlex/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BulmaPhlex
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
This introduces the ability to specify additional classes for the `nav` element as well optionally wrap the content with a container.

This release changes the default behavior of the navigation bar. Previously, it added classes ("is-light block") to the `nav` element and wrapped everything underneath the `nav` element with a container (`<div class="container">`).

To match the prior output, update the call to the component as follows:

    Bulma::NavigationBar(classes: "is-light block", container: true)