### PR TITLE
Title Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This gem provides a set of ready-to-use [Phlex](https://github.com/phlex-ruby/ph
   - [Pagination](#pagination)
   - [Table](#table)
   - [Tabs](#tabs)
+  - [Title and Subtitle](#title-and-subtitle)
 - [Development](#development)
 - [Contributing](#contributing)
 - [License](#license)
@@ -323,6 +324,23 @@ end
 - `active`: Adds the `is-active` class to the tab and shows the related content. Non-active content is assigned the `is-hidden` class. Defaults to `false`.
 - `icon`: Specify an optional icon class.
 
+### Title and Subtitle
+
+The [Title](https://bulma.io/documentation/elements/title/) component provide a way to display headings and subheadings with customizable sizes and styles.
+
+```ruby
+BulmaPhex::Title("Hello World")
+
+BulmaPhex::Title("Dr. Strangelove", size: 2, subtitle: "Or: How I Learned to Stop Worrying and Love the Bomb")
+```
+
+**Constructor Arguments:**
+
+- `text`: (positional, required) The main title text to display.
+- `size`: (optional) An integer from 1 to 6 indicating the size of the title. Corresponds to Bulma's `is-<size>` classes.
+- `subtitle`: (optional) The subtitle text to display below the main title.
+- `subtitle_size`: (optional) An integer from 1 to 6 indicating the size of the subtitle. If not provided and a title size is given, it defaults to `size + 2`.
+- `spaced`: (optional) A boolean indicating whether to add the `is-spaced` class to the title.
 
 ## Development
 

--- a/lib/bulma_phlex/title.rb
+++ b/lib/bulma_phlex/title.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  # # Title
+  #
+  # This component implements the
+  # [Bulma title element](https://bulma.io/documentation/elements/title/). It can optionally
+  # include a subtitle as well.
+  #
+  # ## Parameters
+  #
+  # - `text`: (positional, required) The main title text to display.
+  # - `size`: (optional) An integer from 1 to 6 indicating the size of the title. Corresponds to
+  #     Bulma's `is-<size>` classes.
+  # - `subtitle`: (optional) The subtitle text to display below the main title.
+  # - `subtitle_size`: (optional) An integer from 1 to 6 indicating the size of the subtitle. If
+  #     not provided and a title size is given, it defaults to `size + 2`.
+  # - `spaced`: (optional) A boolean indicating whether to add the `is-spaced` class to the title.
+  #
+  # ## Example
+  #
+  # ```ruby
+  # BulmaPhex::Title("Hello World")
+  # BulmaPhex::Title("Dr. Strangelove", size: 2, subtitle: "Or: How I Learned to Stop Worrying and
+  #   Love the Bomb")
+  # ```
+  class Title < BulmaPhlex::Base
+    def initialize(text, size: nil, subtitle: nil, subtitle_size: nil, spaced: false)
+      @text = text
+      @size = size
+      @subtitle = subtitle
+      @subtitle_size = subtitle_size
+      @spaced = spaced
+    end
+
+    def view_template
+      h1(class: title_classes) { @text }
+      h2(class: subtitle_classes) { @subtitle } if @subtitle
+    end
+
+    private
+
+    def title_classes
+      classes = ["title"]
+      classes << "is-#{@size}" if @size
+      classes << "is-spaced" if @spaced
+      classes.join(" ")
+    end
+
+    def subtitle_classes
+      @subtitle_size = @size + 2 if @size && !@subtitle_size
+      classes = ["subtitle"]
+      classes << "is-#{@subtitle_size}" if @subtitle_size
+      classes.join(" ")
+    end
+  end
+end

--- a/test/bulma_phlex/title_test.rb
+++ b/test/bulma_phlex/title_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module BulmaPhlex
+  class TitleTest < Minitest::Test
+    include TagOutputAssertions
+
+    def test_title_renders_correctly
+      component = Title.new("Hello World")
+      expected_html = '<h1 class="title">Hello World</h1>'
+      assert_html_equal expected_html, component.call
+    end
+
+    def test_title_with_different_size
+      component = Title.new("Hello World", size: 2)
+      expected_html = '<h1 class="title is-2">Hello World</h1>'
+      assert_html_equal expected_html, component.call
+    end
+
+    def test_title_with_subtitle
+      component = Title.new("Hello World", subtitle: "Subtitle here")
+      expected_html = '<h1 class="title">Hello World</h1><h2 class="subtitle">Subtitle here</h2>'
+      assert_html_equal expected_html, component.call
+    end
+
+    def test_with_size_on_title_but_not_on_subtitle
+      component = Title.new("Hello World", size: 3, subtitle: "Subtitle here")
+      expected_html = '<h1 class="title is-3">Hello World</h1><h2 class="subtitle is-5">Subtitle here</h2>'
+      assert_html_equal expected_html, component.call
+    end
+
+    def test_with_size_on_both_title_and_subtitle
+      component = Title.new("Hello World", size: 2, subtitle: "Subtitle here", subtitle_size: 6)
+      expected_html = '<h1 class="title is-2">Hello World</h1><h2 class="subtitle is-6">Subtitle here</h2>'
+      assert_html_equal expected_html, component.call
+    end
+
+    def test_with_spaced_option
+      component = Title.new("Hello World", spaced: true, subtitle: "Nice to see you again")
+      expected_html = '<h1 class="title is-spaced">Hello World</h1><h2 class="subtitle">Nice to see you again</h2>'
+      assert_html_equal expected_html, component.call
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,9 +22,7 @@ module TagOutputAssertions
   def assert_html_equal(expected, actual, message = nil)
     # First try the normal DOM comparison
     assert_dom_equal(expected, actual, message)
-  rescue Minitest::Assertion => e
-    puts "Caught Minitest::Assertion: #{e.class} - #{e.message}"
-
+  rescue Minitest::Assertion
     # If the DOM comparison fails, format the HTML for better readability
     expected_formatted = format_html(expected)
     actual_formatted = format_html(actual)


### PR DESCRIPTION
The [Title](https://bulma.io/documentation/elements/title/) component provide a way to display headings and subheadings with customizable sizes and styles.

```ruby
BulmaPhex::Title("Hello World")

BulmaPhex::Title("Dr. Strangelove", size: 2, subtitle: "Or: How I Learned to Stop Worrying and Love the Bomb")
```

**Constructor Arguments:**

- `text`: (positional, required) The main title text to display.
- `size`: (optional) An integer from 1 to 6 indicating the size of the title. Corresponds to Bulma's `is-<size>` classes.
- `subtitle`: (optional) The subtitle text to display below the main title.
- `subtitle_size`: (optional) An integer from 1 to 6 indicating the size of the subtitle. If not provided and a title size is given, it defaults to `size + 2`.
- `spaced`: (optional) A boolean indicating whether to add the `is-spaced` class to the title.