### PR TITLE
Converts Stimulus "namespace" to bulma-phlex

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ end
 **Options:**
 
 - `label` (required): The dropdown button label.
-- `click`: Stimulus controller name for click-to-toggle (default: `"bulma--dropdown"`). Set to `false` for hoverable.
+- `click`: Stimulus controller name for click-to-toggle (default: `"bulma-phlex--dropdown"`). Set to `false` for hoverable.
 - `alignment`: `:left` (default), `:right`, or `:up`.
 - `icon`: Icon class for the dropdown arrow (default: `"fas fa-angle-down"`).
 
@@ -272,7 +272,7 @@ This generates the [Bulma pagination](https://bulma.io/documentation/components/
 
 The [Tabs](https://bulma.io/documentation/components/tabs/) component provides a way to toggle between different content sections using tabbed navigation, with support for icons and active state management.
 
-Behavior of the tabs can be driven by the data attributes, which are assigned by the object passed in as the `data_attributes_builder`. By default, this will use the `StimulusDataAttributes` class with the controller name `bulma--tabs`. The controller is not provided by this library, but you can create your own Stimulus controller to handle the tab switching logic. Here is [an implementation of a Stimulus controller for Bulma tabs](https://github.com/RockSolt/bulma-rails-helpers/blob/main/app/javascript/controllers/bulma/tabs_controller.js).
+Behavior of the tabs can be driven by the data attributes, which are assigned by the object passed in as the `data_attributes_builder`. By default, this will use the `StimulusDataAttributes` class with the controller name `bulma-phlex--tabs`. The controller is not provided by this library, but you can create your own Stimulus controller to handle the tab switching logic. Here is [an implementation of a Stimulus controller for Bulma tabs](https://github.com/RockSolt/bulma-rails-helpers/blob/main/app/javascript/controllers/bulma/tabs_controller.js).
 
 ```ruby
 BulmaPhex::Tabs(tabs_class: "is-boxed", contents_class: "ml-4") do |tabs|

--- a/lib/bulma_phlex/dropdown.rb
+++ b/lib/bulma_phlex/dropdown.rb
@@ -7,8 +7,8 @@ module BulmaPhlex
   #
   # ## [Hoverable or Toggable](https://bulma.io/documentation/components/dropdown/#hoverable-or-toggable)
   #
-  # By default the dropdown is in Click Mode and assumes a Stimulus controller named `bulma--dropdown` is present to
-  # handle the click events. The controller name can be customized using the `click` option.
+  # By default the dropdown is in Click Mode and assumes a Stimulus controller named `bulma-phlex--dropdown` is present
+  # to handle the click events. The controller name can be customized using the `click` option.
   #
   # Set click to `false` to make the dropdown hoverable instead of togglable.
   #
@@ -36,7 +36,7 @@ module BulmaPhlex
   # ```
   #
   class Dropdown < BulmaPhlex::Base
-    def initialize(label, click: "bulma--dropdown", alignment: "left", icon: "fas fa-angle-down")
+    def initialize(label, click: "bulma-phlex--dropdown", alignment: "left", icon: "fas fa-angle-down")
       @label = label
       @click = click
       @alignment = alignment

--- a/lib/bulma_phlex/navigation_bar.rb
+++ b/lib/bulma_phlex/navigation_bar.rb
@@ -49,7 +49,7 @@ module BulmaPhlex
       nav(class: "navbar #{@classes}".rstrip,
           role: "navigation",
           aria_label: "main navigation",
-          data: { controller: "bulma--navigation-bar" }) do
+          data: { controller: "bulma-phlex--navigation-bar" }) do
         optional_container do
           div(class: "navbar-brand") do
             @brand.each(&:call)
@@ -59,15 +59,15 @@ module BulmaPhlex
               aria_label: "menu",
               aria_expanded: "false",
               data: {
-                action: "bulma--navigation-bar#toggle",
-                "bulma--navigation-bar-target": "burger"
+                action: "bulma-phlex--navigation-bar#toggle",
+                "bulma-phlex--navigation-bar-target": "burger"
               }) do
               4.times { span(aria_hidden: "true") }
             end
           end
 
           div(class: "navbar-menu",
-              data: { "bulma--navigation-bar-target": "menu" }) do
+              data: { "bulma-phlex--navigation-bar-target": "menu" }) do
             div(class: "navbar-start") do
               @left.each(&:call)
             end

--- a/lib/bulma_phlex/tab_components/content.rb
+++ b/lib/bulma_phlex/tab_components/content.rb
@@ -15,7 +15,7 @@ module BulmaPhlex
         @id = id
         @active = active
         @data_attributes = data_attributes_proc ||
-                           BulmaPhlex::Tabs::StimulusDataAttributes.new("bulma--tabs").method(:for_content)
+                           BulmaPhlex::Tabs::StimulusDataAttributes.new("bulma-phlex--tabs").method(:for_content)
       end
 
       def view_template(&)

--- a/lib/bulma_phlex/tab_components/tab.rb
+++ b/lib/bulma_phlex/tab_components/tab.rb
@@ -17,7 +17,7 @@ module BulmaPhlex
     # - `data_attributes_proc`: A proc that generates data attributes for the tab.
     class Tab < BulmaPhlex::Base
       def initialize(id:, title:, icon:, active:,
-                     data_attributes_proc: BulmaPhlex::Tabs::StimulusDataAttributes.new("bulma--tabs").method(:for_tab))
+                     data_attributes_proc: BulmaPhlex::Tabs::StimulusDataAttributes.new("bulma-phlex--tabs").method(:for_tab))
         @id = id
         @title = title
         @icon = icon

--- a/lib/bulma_phlex/tabs.rb
+++ b/lib/bulma_phlex/tabs.rb
@@ -13,9 +13,9 @@ module BulmaPhlex
   # Use method `right_content` to add content to the right of the tabs, such as a button.
   #
   # The tabs behavior can be managed by the data attributes provided by the `data_attributes_builder` argument. By
-  # default, this will use the `StimulusDataAttributes` class with the controller name `bulma--tabs`. That controller
-  # is not provided by this library, but you can create your own Stimulus controller to handle the tab switching
-  # logic. Here is [an implementation of a Stimulus controller for Bulma tabs](https://github.com/RockSolt/bulma-rails-helpers/blob/main/app/javascript/controllers/bulma/tabs_controller.js).
+  # default, this will use the `StimulusDataAttributes` class with the controller name `bulma-phlex--tabs`. That
+  # controlleris not provided by this library, but you can create your own Stimulus controller to handle the tab
+  #  switching logic. Here is [an implementation of a Stimulus controller for Bulma tabs](https://github.com/RockSolt/bulma-rails-helpers/blob/main/app/javascript/controllers/bulma/tabs_controller.js).
   #
   # ## Example
   #
@@ -61,7 +61,7 @@ module BulmaPhlex
     end
 
     def initialize(id: nil, tabs_class: nil, contents_class: nil,
-                   data_attributes_builder: StimulusDataAttributes.new("bulma--tabs"))
+                   data_attributes_builder: StimulusDataAttributes.new("bulma-phlex--tabs"))
       @id = id || "tabs"
       @tabs_class = tabs_class
       @contents_class = contents_class

--- a/test/bulma_phlex/dropdown_test.rb
+++ b/test/bulma_phlex/dropdown_test.rb
@@ -12,9 +12,9 @@ module BulmaPhlex
       result = component.call
 
       expected_html = <<~HTML
-        <div class="dropdown" data-controller="bulma--dropdown">
+        <div class="dropdown" data-controller="bulma-phlex--dropdown">
           <div class="dropdown-trigger">
-            <button class="button" aria-haspopup="true" aria-controls="dropdown-menu" data-action="bulma--dropdown#toggle">
+            <button class="button" aria-haspopup="true" aria-controls="dropdown-menu" data-action="bulma-phlex--dropdown#toggle">
               <span>Menu</span>
               <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
             </button>
@@ -38,9 +38,9 @@ module BulmaPhlex
       end
 
       expected_html = <<~HTML
-        <div class="dropdown" data-controller="bulma--dropdown">
+        <div class="dropdown" data-controller="bulma-phlex--dropdown">
           <div class="dropdown-trigger">
-            <button class="button" aria-haspopup="true" aria-controls="dropdown-menu" data-action="bulma--dropdown#toggle">
+            <button class="button" aria-haspopup="true" aria-controls="dropdown-menu" data-action="bulma-phlex--dropdown#toggle">
               <span>Menu</span>
               <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
             </button>

--- a/test/bulma_phlex/navigation_bar_test.rb
+++ b/test/bulma_phlex/navigation_bar_test.rb
@@ -41,17 +41,17 @@ module BulmaPhlex
       end
 
       expected_structure = <<~HTML
-        <nav class="navbar is-light block" role="navigation" aria-label="main navigation" data-controller="bulma--navigation-bar">
+        <nav class="navbar is-light block" role="navigation" aria-label="main navigation" data-controller="bulma-phlex--navigation-bar">
           <div class="navbar-brand">
             <a href="/" class="navbar-item">Brand</a>
-            <a class="navbar-burger" role="button" aria-label="menu" aria-expanded="false" data-action="bulma--navigation-bar#toggle" data-bulma--navigation-bar-target="burger">
+            <a class="navbar-burger" role="button" aria-label="menu" aria-expanded="false" data-action="bulma-phlex--navigation-bar#toggle" data-bulma-phlex--navigation-bar-target="burger">
               <span aria-hidden="true"></span>
               <span aria-hidden="true"></span>
               <span aria-hidden="true"></span>
               <span aria-hidden="true"></span>
             </a>
           </div>
-          <div class="navbar-menu" data-bulma--navigation-bar-target="menu">
+          <div class="navbar-menu" data-bulma-phlex--navigation-bar-target="menu">
             <div class="navbar-start">
               <a href="/home" class="navbar-item">Home</a>
             </div>
@@ -75,18 +75,18 @@ module BulmaPhlex
       end
 
       expected_structure = <<~HTML
-        <nav class="navbar" role="navigation" aria-label="main navigation" data-controller="bulma--navigation-bar">
+        <nav class="navbar" role="navigation" aria-label="main navigation" data-controller="bulma-phlex--navigation-bar">
           <div class="container">
             <div class="navbar-brand">
               <a href="/" class="navbar-item">Brand</a>
-              <a class="navbar-burger" role="button" aria-label="menu" aria-expanded="false" data-action="bulma--navigation-bar#toggle" data-bulma--navigation-bar-target="burger">
+              <a class="navbar-burger" role="button" aria-label="menu" aria-expanded="false" data-action="bulma-phlex--navigation-bar#toggle" data-bulma-phlex--navigation-bar-target="burger">
                 <span aria-hidden="true"></span>
                 <span aria-hidden="true"></span>
                 <span aria-hidden="true"></span>
                 <span aria-hidden="true"></span>
               </a>
             </div>
-            <div class="navbar-menu" data-bulma--navigation-bar-target="menu">
+            <div class="navbar-menu" data-bulma-phlex--navigation-bar-target="menu">
               <div class="navbar-start">
               </div>
               <div class="navbar-end">

--- a/test/bulma_phlex/tabs_test.rb
+++ b/test/bulma_phlex/tabs_test.rb
@@ -14,21 +14,21 @@ module BulmaPhlex
       end
 
       expected_structure = <<~HTML
-        <div id="tabs" data-controller="bulma--tabs">
+        <div id="tabs" data-controller="bulma-phlex--tabs">
           <div class="tabs">
             <ul id="tabs-tabs">
-              <li id="tab1-tab" data-bulma--tabs-target="tab" data-tab-content="tab1" data-action="click->bulma--tabs#showTabContent" class="is-active">
+              <li id="tab1-tab" data-bulma-phlex--tabs-target="tab" data-tab-content="tab1" data-action="click->bulma-phlex--tabs#showTabContent" class="is-active">
                 <a><span>Tab 1</span></a>
               </li>
-              <li id="tab2-tab" data-bulma--tabs-target="tab" data-tab-content="tab2" data-action="click->bulma--tabs#showTabContent" class="">
+              <li id="tab2-tab" data-bulma-phlex--tabs-target="tab" data-tab-content="tab2" data-action="click->bulma-phlex--tabs#showTabContent" class="">
                 <a><span>Tab 2</span></a>
               </li>
             </ul>
           </div>
 
           <div id="tabs-content" >
-            <div id="tab1" class="" data-bulma--tabs-target="content">Content for Tab 1</div>
-            <div id="tab2" class="is-hidden" data-bulma--tabs-target="content">Content for Tab 2</div>
+            <div id="tab1" class="" data-bulma-phlex--tabs-target="content">Content for Tab 1</div>
+            <div id="tab2" class="is-hidden" data-bulma-phlex--tabs-target="content">Content for Tab 2</div>
           </div>
         </div>
       HTML
@@ -45,15 +45,15 @@ module BulmaPhlex
       end
 
       expected_structure = <<~HTML
-        <div id="tabs" data-controller="bulma--tabs">
+        <div id="tabs" data-controller="bulma-phlex--tabs">
           <div class="columns">
             <div class="column">
               <div class="tabs">
               <ul id="tabs-tabs">
-                  <li id="tab1-tab" data-bulma--tabs-target="tab" data-tab-content="tab1" data-action="click->bulma--tabs#showTabContent" class="is-active">
+                  <li id="tab1-tab" data-bulma-phlex--tabs-target="tab" data-tab-content="tab1" data-action="click->bulma-phlex--tabs#showTabContent" class="is-active">
                   <a><span>Tab 1</span></a>
                   </li>
-                  <li id="tab2-tab" data-bulma--tabs-target="tab" data-tab-content="tab2" data-action="click->bulma--tabs#showTabContent" class="">
+                  <li id="tab2-tab" data-bulma-phlex--tabs-target="tab" data-tab-content="tab2" data-action="click->bulma-phlex--tabs#showTabContent" class="">
                   <a><span>Tab 2</span></a>
                   </li>
               </ul>
@@ -63,8 +63,8 @@ module BulmaPhlex
           </div>
 
           <div id="tabs-content" >
-            <div id="tab1" class="" data-bulma--tabs-target="content">Content for Tab 1</div>
-            <div id="tab2" class="is-hidden" data-bulma--tabs-target="content">Content for Tab 2</div>
+            <div id="tab1" class="" data-bulma-phlex--tabs-target="content">Content for Tab 1</div>
+            <div id="tab2" class="is-hidden" data-bulma-phlex--tabs-target="content">Content for Tab 2</div>
           </div>
         </div>
       HTML


### PR DESCRIPTION
Some of the components include data attributes to support stimulus controllers. The namespace has been updated from `bulma` to `bulma-phlex`.