### PR TITLE
Enable Optional Icons for Card Footer Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ end
 - href: passed to the anchor's `href` attribute
 - Any additional HTML attributes can be passed as keyword arguments.
 
+Icons can be added to the links by passing an `icon` keyword argument with the icon class:
+
+```ruby
+  card.footer_link("View", "/view", icon: "fas fa-eye")
+```
+
 
 ### Dropdown
 

--- a/lib/bulma_phlex/card.rb
+++ b/lib/bulma_phlex/card.rb
@@ -66,9 +66,23 @@ module BulmaPhlex
 
       footer(class: "card-footer") do
         @footer_items.each do |text, href, html_attributes|
+          icon = html_attributes.delete(:icon)
           html_attributes[:class] = [html_attributes[:class], "card-footer-item"].compact.join(" ")
-          a(href:, **html_attributes) { text }
+          a(href:, **html_attributes) do
+            if icon.present?
+              icon_text(icon, text)
+            else
+              plain text
+            end
+          end
         end
+      end
+    end
+
+    def icon_text(icon, text)
+      span(class: "icon-text") do
+        span(class: "icon") { i(class: icon) }
+        span { text }
       end
     end
   end

--- a/test/bulma_phlex/card_test.rb
+++ b/test/bulma_phlex/card_test.rb
@@ -71,5 +71,30 @@ module BulmaPhlex
 
       assert_html_equal expected_html, result
     end
+
+    def test_footer_with_icons
+      component = BulmaPhlex::Card.new
+
+      result = component.call do |card|
+        card.footer_link("Profile", "/profile", icon: "fas fa-user")
+      end
+
+      expected_html = <<~HTML
+        <div class="card">
+          <footer class="card-footer">
+            <a href="/profile" class="card-footer-item">
+              <span class="icon-text">
+                <span class='icon'>
+                  <i class='fas fa-user'></i>
+                </span>
+                <span>Profile</span>
+              </span>
+            </a>
+          </footer>
+        </div>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
   end
 end


### PR DESCRIPTION
Icons can now be added to card footers by passsing in the icon as an option:

    card.footer_link("View", "/view", icon: "fas fa-eye")

<img width="473" height="81" alt="image" src="https://github.com/user-attachments/assets/8ac70f12-abfe-4ed8-9bd7-73a40bcb5a39" />
