### PR TITLE
Tag Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,26 @@ end
 - `active`: Adds the `is-active` class to the tab and shows the related content. Non-active content is assigned the `is-hidden` class. Defaults to `false`.
 - `icon`: Specify an optional icon class.
 
+### Tag
+
+The [Tag](https://bulma.io/documentation/elements/tag/) component provides a way to display small, colored labels or tags with customizable styles. The component generates either a `span`, `a`, or `button` element based on the provided options and HTML attributes.
+
+If the HTML attributes include an `href`, an anchor (`a`) element is generated; if not and either the `delete` option is true or there is a `data-action` attribute, a `button` element is generated; otherwise, a `span` element is used.
+
+```ruby
+BulmaPhex::Tag("New", color: "primary", rounded: true)
+BulmaPhex::Tag("Sale", light: "danger")
+```
+
+**Constructor Arguments:**
+- `text`: (positional, required) The tag text to display.
+- `color`: (optional) The [Bulma color class](https://bulma.io/documentation/elements/tag/#colors) to apply.
+- `light`: (optional) Use instead of `color` to apply a light color variant.
+- `rounded`: (optional) A boolean indicating whether the tag should have rounded corners.
+- `size`: (optional) The [Bulma tag size](https://bulma.io/documentation/elements/tag/#sizes): normal, medium, or large.
+- `delete`: (optional) A boolean indicating whether to include a delete button on the tag.
+
+
 ### Title and Subtitle
 
 The [Title](https://bulma.io/documentation/elements/title/) component provide a way to display headings and subheadings with customizable sizes and styles.

--- a/lib/bulma_phlex/tag.rb
+++ b/lib/bulma_phlex/tag.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  # # Tag
+  #
+  # The Tag component is a bit of a chameleon. It can generate a `span`, `a`, or `button` element
+  # based on the provided attributes. If an `href` attribute is provided, the tag will render as an `a` element. If
+  # the `delete` option is true or a `data-action` attribute is present, it will render as a `button` element.
+  #  Otherwise, it defaults to a `span` element.
+  #
+  # ## Options
+  #
+  # - `delete`: If true, adds a delete button inside the tag.
+  # - `color`: Sets the [color of the tag](https://bulma.io/documentation/elements/tag/#colors)
+  # - `light`: To use a light version of the color, use the key `light` instead of `color`.
+  # - `size`: Sets the [size of the tag](https://bulma.io/documentation/elements/tag/#sizes): normal, medium, or large.
+  # - `rounded`: If true, adds the `is-rounded` class to the tag.
+  #
+  # ## HTML Attributes
+  #
+  # Any additional HTML attributes provided will be applied to the rendered element.
+  class Tag < BulmaPhlex::Base
+    TAG_OPTIONS = %i[delete color light size rounded].freeze
+
+    def initialize(text, **options_and_html_attributes)
+      @text = text
+      @html_attributes = options_and_html_attributes.except(*TAG_OPTIONS)
+      @options = options_and_html_attributes.slice(*TAG_OPTIONS)
+    end
+
+    def view_template
+      if @html_attributes.key?(:href)
+        a(class: tag_classes, **@html_attributes) { text_and_optional_delete_button }
+      elsif @options[:delete] || @html_attributes.dig(:data, :action).present?
+        button(class: tag_classes, **@html_attributes) { text_and_optional_delete_button }
+      else
+        span(class: tag_classes, **@html_attributes) { plain @text }
+      end
+    end
+
+    private
+
+    def text_and_optional_delete_button
+      plain @text
+      return unless @options[:delete]
+
+      size = "is-small" unless @options[:size] == "large"
+      span(class: "delete #{size}".rstrip)
+    end
+
+    def tag_classes
+      classes = ["tag"]
+      classes << "is-#{@options[:color]}" if @options[:color].present?
+      classes << "is-#{@options[:light]} is-light" if @options[:light]
+      classes << "is-#{@options[:size]}" if @options[:size].present?
+      classes << "is-rounded" if @options[:rounded]
+      classes.join(" ")
+    end
+  end
+end

--- a/test/bulma_phlex/tag_test.rb
+++ b/test/bulma_phlex/tag_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module BulmaPhlex
+  class TagTest < Minitest::Test
+    include TagOutputAssertions
+
+    def test_renders_span_tag
+      component = BulmaPhlex::Tag.new("Sample Tag")
+      result = component.call
+
+      expected_html = '<span class="tag">Sample Tag</span>'
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_color
+      component = BulmaPhlex::Tag.new("Sample Tag", color: "primary")
+      result = component.call
+
+      expected_html = '<span class="tag is-primary">Sample Tag</span>'
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_light_color
+      component = BulmaPhlex::Tag.new("Sample Tag", light: "warning")
+      result = component.call
+
+      expected_html = <<~HTML
+        <span class="tag is-warning is-light">Sample Tag</span>
+      HTML
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_size
+      component = BulmaPhlex::Tag.new("Sample Tag", size: "medium")
+      result = component.call
+
+      expected_html = '<span class="tag is-medium">Sample Tag</span>'
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_rounded
+      component = BulmaPhlex::Tag.new("Sample Tag", rounded: true)
+      result = component.call
+
+      expected_html = '<span class="tag is-rounded">Sample Tag</span>'
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_anchor_tag
+      component = BulmaPhlex::Tag.new("Link Tag", href: "/sample-link", size: "large")
+      result = component.call
+
+      expected_html = <<~HTML
+        <a class="tag is-large" href="/sample-link">Link Tag</a>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_anchor_tag_with_delete
+      component = BulmaPhlex::Tag.new("Deletable Tag", href: "/deletable-link", delete: true)
+      result = component.call
+
+      expected_html = <<~HTML
+        <a class="tag" href="/deletable-link">
+          Deletable Tag
+          <span class="delete is-small"></span>
+        </a>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_button_tag
+      component = BulmaPhlex::Tag.new("Button Tag", delete: true)
+      result = component.call
+
+      expected_html = <<~HTML
+        <button class="tag">
+          Button Tag
+          <span class="delete is-small"></span>
+        </button>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_button_tag_with_data_action
+      component = BulmaPhlex::Tag.new("Action Tag", data: { action: "delete" }, color: "info")
+      result = component.call
+
+      expected_html = <<~HTML
+        <button class="tag is-info" data-action="delete">Action Tag</button>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_medium_button_with_small_delete
+      component = BulmaPhlex::Tag.new("Medium Delete", delete: true, size: "medium")
+      result = component.call
+
+      expected_html = <<~HTML
+        <button class="tag is-medium" >
+          Medium Delete
+          <span class="delete is-small"></span>
+        </button>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_large_tag_with_delete
+      component = BulmaPhlex::Tag.new("Large Deletable", delete: true, size: "large")
+      result = component.call
+
+      expected_html = <<~HTML
+        <button class="tag is-large" >
+          Large Deletable
+          <span class="delete"></span>
+        </button>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+  end
+end


### PR DESCRIPTION
This provides a basic Tag component that supports options for color, light, size, rounded, and delete. It generates either an anchor, a button, or a span depending upon the options and html attributes.

```ruby
BulmaPhlex::Tag(filter.label, delete: true,
                              light: 'info',
                              rounded: true,
                              size: 'medium',
                              data: { action: 'filter#remove' })
```

<img width="429" height="49" alt="image" src="https://github.com/user-attachments/assets/2e447aa3-3bb4-403d-892e-5e65e65ffbd5" />
