### PR TITLE
Add ruby versions to testing matrix

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4.3'
+          ruby-version: "3.4.4"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rake rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.4.3'
+          - "3.4"
+          - "4.0"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This expands the rubies in the test matrix to be 3.2 - 4.0.

It also updates the target ruby in the rubocop CI to match the ruby version of 3.4.4.