### PR TITLE
Notification Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Finally, the optional Rails extensions for the Card and Table components have be
   - [Form Field](#form-field)
   - [Level](#level)
   - [NavigationBar](#navigationbar)
+  - [Notification](#notification)
   - [Pagination](#pagination)
   - [Table](#table)
   - [Tabs](#tabs)
@@ -221,6 +222,40 @@ end
 
 > [!NOTE]  
 > Adding a container will limit the width of the Navigation Bar content according to Bulma's container rules. However, the background color of the navbar will still span the full width of the viewport.
+
+
+### Notification
+
+The [Notification](https://bulma.io/documentation/components/notification/) component provides a way to display messages or alerts with customizable styles and a close button.
+
+```ruby
+BulmaPhlex::Notification(color: "info", delete: true) do
+  "This is an informational notification with a close button."
+end
+```
+
+The `delete` keyword argument adds a close button to the notification. In addition to setting it to `true`, it can also be a hash of HTML attributes for the button, such as a data attribute to hook into a Stimulus controller.
+
+```ruby
+BulmaPhlex::Notification(color: "warning", delete: { data: { controller: "bulma-phlex--notification" } }) do
+  "This is a warning notification with a close button that works with a Stimulus controller."
+end
+```
+
+**Constructor Keyword Arguments:**
+
+- `delete`: (optional) When true, adds a close button to the notification. Can also be a hash of HTML attributes for the button.
+- `color`: (optional) The [Bulma color class](https://bulma.io/documentation/elements/tag/#colors) to apply.
+- `mode`: Sets the mode of the notification: "light" or "dark".
+
+Any additional attributes are passed to the notification container div.
+
+```ruby
+BulmaPhlex::Notification(id: "my-notification", class: "ml-3") do
+  "This is a notification with custom id and class."
+end
+```
+
 
 ### Pagination
 

--- a/lib/bulma_phlex/notification.rb
+++ b/lib/bulma_phlex/notification.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  # # Notification
+  #
+  # The Bulma Notification component can be styled with the following options:
+  #
+  # - `delete`: If true, includes a delete button to dismiss the notification. Can also be a hash of HTML
+  # attributes for the button.
+  # - `color`: Sets the color of the notification. Accepts any Bulma color class suffix (e.g., "primary",
+  # "info", "danger").
+  # - `mode`: Sets the mode of the notification: "light" or "dark".
+  #
+  # Any additional HTML attributes passed to the component will be applied to the notification div.
+  #
+  # The content of the notification is provided via a block.
+  class Notification < BulmaPhlex::Base
+    def initialize(delete: false, color: nil, mode: nil, **html_attributes)
+      @delete = delete
+      @color = color
+      @mode = mode
+      @html_attributes = html_attributes
+    end
+
+    def view_template(&)
+      vanish(&)
+
+      div(**mix({ class: notification_classes }, **@html_attributes)) do
+        delete_button if @delete
+        yield
+      end
+    end
+
+    private
+
+    def notification_classes
+      classes = ["notification"]
+      classes << "is-#{@color}" if @color.present?
+      classes << "is-#{@mode}" if @mode.present?
+      classes.join(" ")
+    end
+
+    def delete_button
+      html_attributes = { class: "delete" }
+      html_attributes = mix(html_attributes, @delete) if @delete.is_a?(Hash)
+      button(**html_attributes)
+    end
+  end
+end

--- a/test/bulma_phlex/notification_test.rb
+++ b/test/bulma_phlex/notification_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module BulmaPhlex
+  class NotificationTest < Minitest::Test
+    include TagOutputAssertions
+
+    def test_renders_notification_with_string_content
+      component = BulmaPhlex::Notification.new
+      result = component.call do
+        "Notification content."
+      end
+
+      expected_html = <<~HTML
+        <div class="notification">
+          Notification content.
+        </div>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_notification_with_block_content
+      component = BulmaPhlex::Notification.new
+      result = component.call do |c|
+        c.p { "Hello, World!" }
+      end
+
+      expected_html = <<~HTML
+        <div class="notification">
+          <p>Hello, World!</p>
+        </div>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_renders_with_delete
+      component = BulmaPhlex::Notification.new(delete: true)
+      result = component.call do |c|
+        c.p { "Dismissible notification." }
+      end
+
+      assert_html_equal <<~HTML, result
+        <div class="notification">
+          <button class="delete"></button>
+          <p>Dismissible notification.</p>
+        </div>
+      HTML
+    end
+
+    def test_renders_with_color
+      component = BulmaPhlex::Notification.new(color: "primary")
+      results = component.call do |c|
+        c.p { "Primary notification." }
+      end
+
+      assert_html_equal <<~HTML, results
+        <div class="notification is-primary">
+          <p>Primary notification.</p>
+        </div>
+      HTML
+    end
+
+    def test_renders_light_color
+      component = BulmaPhlex::Notification.new(color: "primary", mode: "light")
+      results = component.call do |c|
+        c.p { "Primary notification." }
+      end
+
+      assert_html_equal <<~HTML, results
+        <div class="notification is-primary is-light">
+          <p>Primary notification.</p>
+        </div>
+      HTML
+    end
+
+    def test_with_data_attributes_for_delete
+      component = BulmaPhlex::Notification.new(delete: { data: { action: "notification#close" } })
+      result = component.call do |c|
+        c.p { "Notification with data attributes." }
+      end
+
+      expected_html = <<~HTML
+        <div class="notification">
+          <button class="delete" data-action="notification#close"></button>
+          <p>Notification with data attributes.</p>
+        </div>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_with_additional_classes
+      component = BulmaPhlex::Notification.new(class: "custom-class another-class", color: "info")
+      result = component.call do |c|
+        c.p { "Notification with additional classes." }
+      end
+
+      expected_html = <<~HTML
+        <div class="notification is-info custom-class another-class">
+          <p>Notification with additional classes.</p>
+        </div>
+      HTML
+      assert_html_equal expected_html, result
+    end
+
+    def test_with_id
+      component = BulmaPhlex::Notification.new(delete: true, id: "custom-notification", color: "primary")
+      result = component.call do |c|
+        c.p { "Notification with custom ID." }
+      end
+
+      expected_html = <<~HTML
+        <div class="notification is-primary" id="custom-notification">
+          <button class="delete"></button>
+          <p>Notification with custom ID.</p>
+        </div>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_with_additional_classes_on_delete_button
+      component = BulmaPhlex::Notification.new(delete: { class: "custom-delete-class" }, color: "warning")
+      result = component.call do |c|
+        c.p { "Notification with custom delete button class." }
+      end
+
+      expected_html = <<~HTML
+        <div class="notification is-warning">
+          <button class="delete custom-delete-class"></button>
+          <p>Notification with custom delete button class.</p>
+        </div>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+  end
+end


### PR DESCRIPTION
This adds the Notification component. It includes the ability to add any html attributes to either the main div or the delete button using the mix. This is a pattern that should be used across the other components to add flexibility.

The following options are also supported:
- delete: defaults to false, pass in true or html attributes to include the delete button
- color: for example, info or success
- mode: light or dark