### PR TITLE
Form Field: Implicit Control

### DIFF
--- a/lib/bulma_phlex/form_field.rb
+++ b/lib/bulma_phlex/form_field.rb
@@ -56,6 +56,17 @@ module BulmaPhlex
   # end
   # ```
   #
+  # ### Shorthand with no Label
+  #
+  # If no label is needed, you can use the shorthand syntax which just puts the control
+  # in the block without needing to call `control` explicitly:
+  #
+  # ```ruby
+  # FormField(help: "Enter the project name.") do
+  #   input id: "project_name", name: "project[name]", type: "text"
+  # end
+  # ```
+  #
   # ## References
   #
   # - [Bulma Form Field](https://bulma.io/documentation/form/general/#form-field)
@@ -84,8 +95,9 @@ module BulmaPhlex
       @control_builder = block
     end
 
-    def view_template(&)
-      vanish(&)
+    def view_template(&implicit_control)
+      @control_builder = implicit_control if @control_builder.nil? && implicit_control
+      vanish(&implicit_control)
 
       div(class: field_classes) do
         render_label

--- a/test/bulma_phlex/form_field_test.rb
+++ b/test/bulma_phlex/form_field_test.rb
@@ -243,6 +243,21 @@ module BulmaPhlex
       assert_html_equal expected_html, output
     end
 
+    def test_with_no_label_control_block_is_implicit
+      component = FormField.new(grid: "col-span-2")
+      output = component.call do
+        input_builder
+      end
+
+      assert_html_equal <<~HTML, output
+        <div class="field cell is-col-span-2">
+          <div class="control">
+            <input name="test_input" type="text" />
+          </div>
+        </div>
+      HTML
+    end
+
     private
 
     def label_builder


### PR DESCRIPTION
This is a small developer experience change. If a form field does not include a label, then you can pass the control directly in the block without needing to call `field.control`. It just eliminates a block in those cases.