### PR TITLE
HTML Attributes for Grid

### DIFF
--- a/lib/bulma_phlex/grid.rb
+++ b/lib/bulma_phlex/grid.rb
@@ -20,18 +20,20 @@ module BulmaPhlex
                    minimum_column_width: nil,
                    gap: nil,
                    column_gap: nil,
-                   row_gap: nil)
+                   row_gap: nil,
+                   **html_attributes)
       @fixed_columns = fixed_columns
       @auto_count = auto_count
       @minimum_column_width = minimum_column_width
       @gap = gap
       @column_gap = column_gap
       @row_gap = row_gap
+      @html_attributes = html_attributes
     end
 
     def view_template(&)
       optional_fixed_grid_wrapper do
-        div(class: grid_classes, &)
+        div(**mix({ class: grid_classes }, @html_attributes), &)
       end
     end
 
@@ -39,7 +41,10 @@ module BulmaPhlex
 
     def optional_fixed_grid_wrapper(&)
       if @fixed_columns || @auto_count
-        div(class: fixed_grid_classes, &)
+        div(**mix({ class: fixed_grid_classes }, @html_attributes)) do
+          @html_attributes = {}
+          yield
+        end
       else
         yield
       end

--- a/test/bulma_phlex/grid_test.rb
+++ b/test/bulma_phlex/grid_test.rb
@@ -17,12 +17,36 @@ module BulmaPhlex
       HTML
     end
 
+    def test_html_attributes
+      component = Grid.new(id: "my-grid", data: { test: "value" })
+      output = component.call { "Content" }
+
+      assert_html_equal <<~HTML, output
+        <div class="grid" id="my-grid" data-test="value">
+          Content
+        </div>
+      HTML
+    end
+
     def test_fixed_columns
       component = Grid.new(fixed_columns: 3)
       output = component.call { "Content" }
 
       assert_html_equal <<~HTML, output
         <div class="fixed-grid has-3-cols">
+          <div class="grid">
+            Content
+          </div>
+        </div>
+      HTML
+    end
+
+    def test_fixed_columns_with_html_attributes
+      component = Grid.new(fixed_columns: 4, id: "my-grid", data: { test: "value" })
+      output = component.call { "Content" }
+
+      assert_html_equal <<~HTML, output
+        <div class="fixed-grid has-4-cols" id="my-grid" data-test="value">
           <div class="grid">
             Content
           </div>


### PR DESCRIPTION
This uses the `mix` method to allow additional html attributes to be assigned. The assignment always goes on the outer container.