### PR TITLE
Button Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Finally, the optional Rails extensions for the Card and Table components have be
 
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Button](#button)
   - [Card](#card)
   - [Columns](#columns)
   - [Dropdown](#dropdown)
@@ -86,6 +87,34 @@ require "bulma-phlex"
 ## Usage
 
 Use the Phlex components in your Rails views or any Ruby application that supports Phlex components.
+
+### Button
+
+The [Button](https://bulma.io/documentation/elements/button/) component provides a way to create styled buttons with various options for colors, sizes, and icons.
+
+```ruby
+BulmaPhlex::Button(color: "primary", size: "large", icon: "fas fa-thumbs-up") { "Like" }
+```
+
+**Constructor Keyword Arguments:**
+
+- `color`: Sets the button color (e.g., "primary", "link", "info", "success", "warning", "danger").
+- `mode`: Sets the mode of the notification: "light" or "dark".
+- `size`: Sets the button size: "small", "normal" (the default), "medium", or "large".
+- `responsive`: If `true`, makes the button responsive.
+- `fullwidth`: If `true`, makes the button full width.
+- `outlined`: If `true`, makes the button outlined.
+- `inverted`: If `true`, makes the button inverted.
+- `rounded`: If `true`, makes the button rounded.
+- `icon`: If provided, adds an icon to the button. Should be a string representing the 
+  icon class (e.g., "fa-solid fa-check").
+- `icon_left`: If provided, adds an icon to the left of the button text. Should be a string
+  representing the icon class (e.g., "fa-solid fa-check").
+- `icon_right`: If provided, adds an icon to the right of the button text. Should be a string
+  representing the icon class (e.g., "fa-solid fa-check").
+
+Any additional HTML attributes passed to the constructor will be applied to the button element.
+
 
 ### Card
 

--- a/lib/bulma_phlex/button.rb
+++ b/lib/bulma_phlex/button.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  # # Button
+  #
+  # This component implements the [Bulma button](https://bulma.io/documentation/elements/button/)
+  # interface. It provides a simple way to create buttons with the appropriate Bulma classes.
+  #
+  # ## Options
+  #
+  # - `color`: Sets the button color (e.g., "primary", "link", "info", "success", "warning", "danger").
+  # - `mode`: Sets the mode of the notification: "light" or "dark".
+  # - `size`: Sets the button size: "small", "normal" (the default), "medium", or "large".
+  # - `responsive`: If `true`, makes the button responsive.
+  # - `fullwidth`: If `true`, makes the button full width.
+  # - `outlined`: If `true`, makes the button outlined.
+  # - `inverted`: If `true`, makes the button inverted.
+  # - `rounded`: If `true`, makes the button rounded.
+  # - `icon`: If provided, adds an icon to the button. Should be a string representing
+  #   the icon class (e.g., "fa-solid fa-check").
+  # - `icon_left`: If provided, adds an icon to the left of the button text. Should be a string
+  #   representing the icon class (e.g., "fa-solid fa-check").
+  # - `icon_right`: If provided, adds an icon to the right of the button text. Should be a string
+  #   representing the icon class (e.g., "fa-solid fa-check").
+  class Button < Base
+    def initialize(color: nil, # rubocop:disable Metrics/ParameterLists
+                   mode: nil,
+                   size: nil,
+                   responsive: false,
+                   fullwidth: false,
+                   outlined: false,
+                   inverted: false,
+                   rounded: false,
+                   icon: nil,
+                   icon_left: nil,
+                   icon_right: nil,
+                   **html_attributes)
+      @color = color
+      @mode = mode
+      @size = size
+      @responsive = responsive
+      @fullwidth = fullwidth
+      @outlined = outlined
+      @inverted = inverted
+      @rounded = rounded
+      @icon_left = icon || icon_left
+      @icon_right = icon_right
+      @html_attributes = html_attributes
+    end
+
+    def view_template(&)
+      button(**mix({ class: button_classes }, @html_attributes)) do
+        Icon(@icon_left) if @icon_left
+        yield if block_given?
+        Icon(@icon_right) if @icon_right
+      end
+    end
+
+    private
+
+    def button_classes # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      classes = ["button"]
+      classes << "is-#{@color}" if @color
+      classes << "is-#{@mode}" if @mode
+      classes << "is-#{@size}" if @size
+      classes << "is-responsive" if @responsive
+      classes << "is-fullwidth" if @fullwidth
+      classes << "is-outlined" if @outlined
+      classes << "is-inverted" if @inverted
+      classes << "is-rounded" if @rounded
+      classes
+    end
+  end
+end

--- a/test/bulma_phlex/button_test.rb
+++ b/test/bulma_phlex/button_test.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module BulmaPhlex
+  class ButtonTest < Minitest::Test
+    include TagOutputAssertions
+
+    def test_button
+      component = BulmaPhlex::Button.new
+      result = component.call { "Click Me" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button">
+          Click Me
+        </button>
+      HTML
+    end
+
+    def test_color
+      component = BulmaPhlex::Button.new(color: "primary")
+      result = component.call { "Primary Button" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button is-primary">
+          Primary Button
+        </button>
+      HTML
+    end
+
+    def test_mode
+      component = BulmaPhlex::Button.new(color: "primary", mode: "dark")
+      result = component.call { "Dark Primary Button" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button is-primary is-dark">
+          Dark Primary Button
+        </button>
+      HTML
+    end
+
+    def test_size
+      component = BulmaPhlex::Button.new(size: "large")
+      result = component.call { "Large Button" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button is-large">
+          Large Button
+        </button>
+      HTML
+    end
+
+    def test_responsive
+      component = BulmaPhlex::Button.new(responsive: true)
+      result = component.call { "Responsive Button" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button is-responsive">
+          Responsive Button
+        </button>
+      HTML
+    end
+
+    def test_fullwidth
+      component = BulmaPhlex::Button.new(fullwidth: true)
+      result = component.call { "Fullwidth Button" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button is-fullwidth">
+          Fullwidth Button
+        </button>
+      HTML
+    end
+
+    def test_outlined
+      component = BulmaPhlex::Button.new(outlined: true)
+      result = component.call { "Outlined Button" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button is-outlined">
+          Outlined Button
+        </button>
+      HTML
+    end
+
+    def test_inverted
+      component = BulmaPhlex::Button.new(inverted: true)
+      result = component.call { "Inverted Button" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button is-inverted">
+          Inverted Button
+        </button>
+      HTML
+    end
+
+    def test_rounded
+      component = BulmaPhlex::Button.new(rounded: true)
+      result = component.call { "Rounded Button" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button is-rounded">
+          Rounded Button
+        </button>
+      HTML
+    end
+
+    def test_icon_left
+      component = BulmaPhlex::Button.new(icon_left: "fas fa-pencil")
+      result = component.call { "Button with Left Icon" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button">
+          <span class="icon">
+            <i class="fas fa-pencil"></i>
+          </span>
+          Button with Left Icon
+        </button>
+      HTML
+    end
+
+    def test_icon_right
+      component = BulmaPhlex::Button.new(icon_right: "fas fa-trash")
+      result = component.call { "Button with Right Icon" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button">
+          Button with Right Icon
+          <span class="icon">
+            <i class="fas fa-trash"></i>
+          </span>
+        </button>
+      HTML
+    end
+
+    def test_icon
+      component = BulmaPhlex::Button.new(icon: "fas fa-check")
+      result = component.call
+
+      assert_html_equal <<~HTML, result
+        <button class="button">
+          <span class="icon">
+            <i class="fas fa-check"></i>
+          </span>
+        </button>
+      HTML
+    end
+
+    def test_with_html_attributes
+      component = BulmaPhlex::Button.new(color: "primary", data: { test: "value" }, id: "my-button")
+      result = component.call { "Button with HTML Attributes" }
+
+      assert_html_equal <<~HTML, result
+        <button class="button is-primary" data-test="value" id="my-button">
+          Button with HTML Attributes
+        </button>
+      HTML
+    end
+  end
+end


### PR DESCRIPTION
This adds the button component with options to support all the Bulma CSS:

- `color`: Sets the button color (e.g., "primary", "link", "info", "success", "warning", "danger").
- `mode`: Sets the mode of the notification: "light" or "dark".
- `size`: Sets the button size: "small", "normal" (the default), "medium", or "large".
- `responsive`: If `true`, makes the button responsive.
- `fullwidth`: If `true`, makes the button full width.
- `outlined`: If `true`, makes the button outlined.
- `inverted`: If `true`, makes the button inverted.
- `rounded`: If `true`, makes the button rounded.
- `icon`: If provided, adds an icon to the button. Should be a string representing the icon class (e.g., "fa-solid fa-check").
- `icon_left`: If provided, adds an icon to the left of the button text. Should be a string representing the icon class (e.g., "fa-solid fa-check").
- `icon_right`: If provided, adds an icon to the right of the button text. Should be a string representing the icon class (e.g., "fa-solid fa-check").