### PR TITLE
Tabs: Refactor Options, Support HTML Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,10 +492,10 @@ This generates the [Bulma pagination](https://bulma.io/documentation/components/
 
 The [Tabs](https://bulma.io/documentation/components/tabs/) component provides a way to toggle between different content sections using tabbed navigation, with support for icons and active state management.
 
-Behavior of the tabs can be driven by the data attributes, which are assigned by the object passed in as the `data_attributes_builder`. By default, this will use the `StimulusDataAttributes` class with the controller name `bulma-phlex--tabs`. The controller is not provided by this library, but you can create your own Stimulus controller to handle the tab switching logic. Here is [an implementation of a Stimulus controller for Bulma tabs](https://github.com/RockSolt/bulma-rails-helpers/blob/main/app/javascript/controllers/bulma/tabs_controller.js).
+Behavior of the tabs can be driven by the data attributes, which are assigned by the object passed in as the `data_attributes_builder`. By default, this will use the `StimulusDataAttributes` class with the controller name `bulma-phlex--tabs`. The controller is not provided by this library, but you can create your own Stimulus controller to handle the tab switching logic. Here is [an implementation of a Stimulus controller for Bulma tabs](https://github.com/RockSolt/bulma-phlex-rails/blob/main/app/javascript/controllers/bulma_phlex/tabs_controller.js).
 
 ```ruby
-BulmaPhlex::Tabs(tabs_class: "is-boxed", contents_class: "ml-4") do |tabs|
+BulmaPhlex::Tabs(boxed: true) do |tabs|
   tabs.tab(id: "profile", title: "Profile", active: true) do
     "Profile content goes here"
   end
@@ -512,9 +512,15 @@ end
 
 **Constructor Keyword Arguments:**
 
-- `tabs_class`: Classes to be added to the tabs div, such as `is-boxed`, `is-medium`, `is-centered`, or `is-toggle`.
-- `contents_class`: Classes added to the div that wraps the content (no Bulma related tabs functionality here, just a hook).
+- `align`: Can be `centered` or `right` to align the tabs accordingly.
+- `size`: Can be `small`, `medium`, or `large` to set the size of the tabs.
+- `boxed`: If `true`, uses classic style tabs.
+- `toggle`: If `true`, makes the tabs look like buttons.
+- `rounded`: If `true`, makes the tabs look like buttons with the first and last rounded.
+- `fullwidth`: If `true`, makes the tabs take up the full width of the container.
 - `data_attributes_builder`: Builder object that responds to `for_container`, `for_tab`, and `for_content` (with the latter two receiving the tab `id`). See the default `StimulusDataAttributes` for an example.
+
+Any additional HTML attributes passed to the component will be applied to the outer `<div>` element.
 
 **Keyword Arguments for `tab` Method:**
 

--- a/test/bulma_phlex/tabs_test.rb
+++ b/test/bulma_phlex/tabs_test.rb
@@ -14,9 +14,9 @@ module BulmaPhlex
       end
 
       expected_structure = <<~HTML
-        <div id="tabs" data-controller="bulma-phlex--tabs">
+        <div data-controller="bulma-phlex--tabs">
           <div class="tabs">
-            <ul id="tabs-tabs">
+            <ul>
               <li id="tab1-tab" data-bulma-phlex--tabs-target="tab" data-tab-content="tab1" data-action="click->bulma-phlex--tabs#showTabContent" class="is-active">
                 <a><span>Tab 1</span></a>
               </li>
@@ -26,7 +26,7 @@ module BulmaPhlex
             </ul>
           </div>
 
-          <div id="tabs-content" >
+          <div>
             <div id="tab1" class="" data-bulma-phlex--tabs-target="content">Content for Tab 1</div>
             <div id="tab2" class="is-hidden" data-bulma-phlex--tabs-target="content">Content for Tab 2</div>
           </div>
@@ -44,12 +44,12 @@ module BulmaPhlex
         tabs.right_content { "ON THE RIGHT" }
       end
 
-      expected_structure = <<~HTML
-        <div id="tabs" data-controller="bulma-phlex--tabs">
+      assert_html_equal <<~HTML, result
+        <div data-controller="bulma-phlex--tabs">
           <div class="columns">
             <div class="column">
               <div class="tabs">
-              <ul id="tabs-tabs">
+              <ul>
                   <li id="tab1-tab" data-bulma-phlex--tabs-target="tab" data-tab-content="tab1" data-action="click->bulma-phlex--tabs#showTabContent" class="is-active">
                   <a><span>Tab 1</span></a>
                   </li>
@@ -62,18 +62,16 @@ module BulmaPhlex
             <div class="column is-narrow">ON THE RIGHT</div>
           </div>
 
-          <div id="tabs-content" >
+          <div>
             <div id="tab1" class="" data-bulma-phlex--tabs-target="content">Content for Tab 1</div>
             <div id="tab2" class="is-hidden" data-bulma-phlex--tabs-target="content">Content for Tab 2</div>
           </div>
         </div>
       HTML
-
-      assert_html_equal expected_structure, result
     end
 
-    def test_tabs_class
-      component = BulmaPhlex::Tabs.new(tabs_class: "is-boxed")
+    def test_boxed
+      component = BulmaPhlex::Tabs.new(boxed: true)
 
       result = component.call do |tabs|
         tabs.tab(id: "tab1", title: "Settings", icon: "fas fa-cog") do
@@ -84,8 +82,8 @@ module BulmaPhlex
       assert_html_includes result, '<div class="tabs is-boxed">'
     end
 
-    def test_contents_class
-      component = BulmaPhlex::Tabs.new(contents_class: "ml-4")
+    def test_align_centered
+      component = BulmaPhlex::Tabs.new(align: :centered)
 
       result = component.call do |tabs|
         tabs.tab(id: "tab1", title: "Settings", icon: "fas fa-cog") do
@@ -93,7 +91,67 @@ module BulmaPhlex
         end
       end
 
-      assert_html_includes result, '<div id="tabs-content" class="ml-4">'
+      assert_html_includes result, '<div class="tabs is-centered">'
+    end
+
+    def test_align_right
+      component = BulmaPhlex::Tabs.new(align: :right)
+
+      result = component.call do |tabs|
+        tabs.tab(id: "tab1", title: "Settings", icon: "fas fa-cog") do
+          "Settings content"
+        end
+      end
+
+      assert_html_includes result, '<div class="tabs is-right">'
+    end
+
+    def test_size
+      component = BulmaPhlex::Tabs.new(size: "small")
+
+      result = component.call do |tabs|
+        tabs.tab(id: "tab1", title: "Settings", icon: "fas fa-cog") do
+          "Settings content"
+        end
+      end
+
+      assert_html_includes result, '<div class="tabs is-small">'
+    end
+
+    def test_toggle
+      component = BulmaPhlex::Tabs.new(toggle: true)
+
+      result = component.call do |tabs|
+        tabs.tab(id: "tab1", title: "Settings", icon: "fas fa-cog") do
+          "Settings content"
+        end
+      end
+
+      assert_html_includes result, '<div class="tabs is-toggle">'
+    end
+
+    def test_rounded
+      component = BulmaPhlex::Tabs.new(rounded: true)
+
+      result = component.call do |tabs|
+        tabs.tab(id: "tab1", title: "Settings", icon: "fas fa-cog") do
+          "Settings content"
+        end
+      end
+
+      assert_html_includes result, '<div class="tabs is-toggle is-toggle-rounded">'
+    end
+
+    def test_fullwidth
+      component = BulmaPhlex::Tabs.new(fullwidth: true)
+
+      result = component.call do |tabs|
+        tabs.tab(id: "tab1", title: "Settings", icon: "fas fa-cog") do
+          "Settings content"
+        end
+      end
+
+      assert_html_includes result, '<div class="tabs is-fullwidth">'
     end
 
     def test_renders_tabs_with_icons
@@ -107,6 +165,18 @@ module BulmaPhlex
 
       assert_html_includes result, '<span class="icon mr-1"><i class="fas fa-cog"></i></span>'
       assert_html_includes result, "<span>Settings</span>"
+    end
+
+    def test_with_additional_html_attributes
+      component = BulmaPhlex::Tabs.new(id: "my-tabs", data: { custom: "value" })
+
+      result = component.call do |tabs|
+        tabs.tab(id: "tab1", title: "Settings", icon: "fas fa-cog") do
+          "Settings content"
+        end
+      end
+
+      assert_html_includes result, '<div data-controller="bulma-phlex--tabs" data-custom="value" id="my-tabs"'
     end
 
     private


### PR DESCRIPTION
Add arguments for the Bulma CSS options instead of requiring the classes to be specified. This makes the component like the others.

This also introduces the ability to add any additional HTML attributes to the outer `div`.

This does remove the argument `content_class` and does not replace that functionality. There's not much need to apply classes to the `div` surrounding the content; this was in place as a parallel to `tabs_classes`, but never saw much use.