### PR TITLE
Modify rubocop for Metrics/ParameterLists -> CountKeywordArgs: false

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://www.rubyschema.org/rubocop.json
+
 AllCops:
   TargetRubyVersion: 3.2
   NewCops: enable
@@ -25,6 +27,8 @@ Metrics/CyclomaticComplexity:
     - lib/bulma_phlex/pagination.rb
 Metrics/MethodLength:
   Enabled: false
+Metrics/ParameterLists:
+  CountKeywordArgs: false
 Metrics/PerceivedComplexity:
   Exclude:
     - lib/bulma_phlex/pagination.rb

--- a/lib/bulma_phlex/button.rb
+++ b/lib/bulma_phlex/button.rb
@@ -23,7 +23,7 @@ module BulmaPhlex
   # - `icon_right`: If provided, adds an icon to the right of the button text. Should be a string
   #   representing the icon class (e.g., "fa-solid fa-check").
   class Button < Base
-    def initialize(color: nil, # rubocop:disable Metrics/ParameterLists
+    def initialize(color: nil,
                    mode: nil,
                    size: nil,
                    responsive: false,

--- a/lib/bulma_phlex/columns.rb
+++ b/lib/bulma_phlex/columns.rb
@@ -14,7 +14,7 @@ module BulmaPhlex
   # - `centered`: (Boolean, optional) If true, centers the columns.
   # - `vcentered`: (Boolean, optional) If true, vertically centers the columns.
   class Columns < BulmaPhlex::Base
-    def initialize(minimum_breakpoint: nil, # rubocop:disable Metrics/ParameterLists
+    def initialize(minimum_breakpoint: nil,
                    multiline: false,
                    gap: nil,
                    centered: false,

--- a/lib/bulma_phlex/grid.rb
+++ b/lib/bulma_phlex/grid.rb
@@ -15,7 +15,7 @@ module BulmaPhlex
   # - `column_gap`: (optional) Sets the column gap size between grid items from 1-8 with 0.5 increments.
   # - `row_gap`: (optional) Sets the row gap size between grid items from 1-8 with 0.5 increments.
   class Grid < BulmaPhlex::Base
-    def initialize(fixed_columns: nil, # rubocop:disable Metrics/ParameterLists
+    def initialize(fixed_columns: nil,
                    auto_count: false,
                    minimum_column_width: nil,
                    gap: nil,

--- a/lib/bulma_phlex/icon.rb
+++ b/lib/bulma_phlex/icon.rb
@@ -22,7 +22,7 @@ module BulmaPhlex
   # BulmaPhlex::Icon.new("fas fa-home", color: :primary, size: :large, text_right: "Home")
   # ```
   class Icon < BulmaPhlex::Base
-    def initialize(icon, # rubocop:disable Metrics/ParameterLists
+    def initialize(icon,
                    text_right: nil,
                    text_left: nil,
                    size: nil,

--- a/lib/bulma_phlex/navigation_bar.rb
+++ b/lib/bulma_phlex/navigation_bar.rb
@@ -49,7 +49,7 @@ module BulmaPhlex
   #
   # Any additional HTML attributes passed to the component will be applied to the `<nav>` element.
   class NavigationBar < BulmaPhlex::Base
-    def initialize(container: false, # rubocop:disable Metrics/ParameterLists
+    def initialize(container: false,
                    color: nil,
                    transparent: false,
                    spaced: false,

--- a/lib/bulma_phlex/table.rb
+++ b/lib/bulma_phlex/table.rb
@@ -43,7 +43,7 @@ module BulmaPhlex
   # will be rendered in the table footer. The block should accept a page number and return the
   # corresponding URL for that page.
   class Table < BulmaPhlex::Base
-    def initialize(rows, # rubocop:disable Metrics/ParameterLists
+    def initialize(rows,
                    bordered: false,
                    striped: false,
                    narrow: false,

--- a/lib/bulma_phlex/tabs.rb
+++ b/lib/bulma_phlex/tabs.rb
@@ -69,7 +69,7 @@ module BulmaPhlex
       end
     end
 
-    def initialize(align: nil, # rubocop:disable Metrics/ParameterLists
+    def initialize(align: nil,
                    size: nil,
                    boxed: false,
                    toggle: false,


### PR DESCRIPTION
A number of the components have a list of options that goes beyond the limit for this cop. I prefer them as keyword arguments than a hash of options that is not as well defined.