### PR TITLE
Modal Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This gem provides a set of ready-to-use [Phlex](https://github.com/phlex-ruby/ph
   - [Grid](#grid)
   - [Icon](#icon)
   - [Level](#level)
+  - [Modal](#modal)
   - [NavigationBar](#navigationbar)
   - [Notification](#notification)
   - [Pagination](#pagination)
@@ -283,6 +284,27 @@ end
 ```
 
 Pass in any HTML attributes to the constructor to have them applied to the level container div.
+
+
+### Modal
+
+The [Modal](https://bulma.io/documentation/components/modal/) component provides a way to create modal dialogs with customizable content and styling options.
+
+```ruby
+BulmaPhlex::Modal.new do
+  div(class: "box") do
+    h1(class: "title") { "Modal Title" }
+    p { "This is the modal content." }
+  end
+end
+```
+
+**Constructor Keyword Arguments:**
+
+- `data_attributes_builder`: A builder object that responds to `for_container`, `for_background`, and `for_close_button`, which should return a hash of data attributes for the container, background, and close button, respectively. By default, this uses the nested `StimulusDataAttributes` class with the controller name `bulma-phlex--modal`. You can create your own builder to integrate with a different JavaScript framework or custom logic.
+
+Any additional HTML attributes passed to the constructor will be applied to the modal container div. The modal can be toggled by adding or removing the `is-active` class on the container. (Nothing in the component adds the `is-active` class, so you will need to handle that with your own JavaScript or Stimulus controller.)
+
 
 ### NavigationBar
 

--- a/lib/bulma_phlex/modal.rb
+++ b/lib/bulma_phlex/modal.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  # ## Modal
+  #
+  # The Bulma Modal component is used to create modal dialogs. It consists of a background,
+  # content area, and a close button. The content of the modal can be defined using the block
+  # passed to the `call` method.
+  #
+  # The constructor accepts an optional `data_attributes_builder` argument, which allows you to
+  # provide data attributes for the container, background, and close button. By default, it uses a
+  # `StimulusDataAttributes` instance with the controller name "bulma-phlex--modal". You can provide your
+  # own builder if you want to use a different controller or customize the data attributes further.
+  #
+  # Any additional HTML attributes passed to the constructor will be applied to the outer `<div>`
+  # element of the modal.
+  class Modal < BulmaPhlex::Base
+    StimulusDataAttributes = Data.define(:stimulus_controller) do
+      def for_container = { controller: stimulus_controller }
+      def for_background = { action: "click->bulma-phlex--modal#close" }
+      def for_close_button = { action: "bulma-phlex--modal#close" }
+    end
+
+    def initialize(data_attributes_builder: StimulusDataAttributes.new("bulma-phlex--modal"), **html_attributes)
+      @data_attributes_builder = data_attributes_builder
+      @html_attributes = html_attributes
+    end
+
+    def view_template(&)
+      container = { class: "modal", data: @data_attributes_builder.for_container }
+      div(**mix(container, @html_attributes)) do
+        div(class: "modal-background", data: @data_attributes_builder.for_background)
+        div(class: "modal-content", &)
+        button(class: "modal-close is-large", aria: { label: "close" }, data: @data_attributes_builder.for_close_button)
+      end
+    end
+  end
+end

--- a/test/bulma_phlex/modal_test.rb
+++ b/test/bulma_phlex/modal_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module BulmaPhlex
+  class ModalTest < Minitest::Test
+    include TagOutputAssertions
+
+    def test_renders_basic_modal
+      component = BulmaPhlex::Modal.new
+      result = component.call do
+        "Modal content goes here"
+      end
+
+      assert_html_equal <<~HTML, result
+        <div class="modal" data-controller="bulma-phlex--modal">
+          <div class="modal-background" data-action="click->bulma-phlex--modal#close"></div>
+          <div class="modal-content">
+            Modal content goes here
+          </div>
+          <button class="modal-close is-large" aria-label="close" data-action="bulma-phlex--modal#close"></button>
+        </div>
+      HTML
+    end
+
+    def test_renders_modal_with_additional_classes
+      component = BulmaPhlex::Modal.new(class: "is-active", data: { test: "value" })
+      result = component.call do
+        "Active modal content"
+      end
+
+      assert_html_equal <<~HTML, result
+        <div class="modal is-active" data-controller="bulma-phlex--modal" data-test="value">
+          <div class="modal-background" data-action="click->bulma-phlex--modal#close"></div>
+          <div class="modal-content">
+            Active modal content
+          </div>
+          <button class="modal-close is-large" aria-label="close" data-action="bulma-phlex--modal#close"></button>
+        </div>
+      HTML
+    end
+  end
+end


### PR DESCRIPTION
This adds a Modal component. By default it will use data attributes for a Stimulus controller named `bulma-phlex--modal`, though this does not include that controller. (Stay tuned for it to be added to the Bulma Phlex Rails gem.)