### PR TITLE
Enable html attributes in FormField#label

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Renders a [Bulma form field](https://bulma.io/documentation/form/general/#form-f
 
 ```ruby
 render BulmaPhlex::FormField.new(help: "We'll never share your email.") do |field|
-  field.label("Email Address")
+  field.label("Email Address", for: "user_email_address")
   field.control { input(name: "user[email_address]", type: "email") }
 end
 ```

--- a/lib/bulma_phlex/form_field.rb
+++ b/lib/bulma_phlex/form_field.rb
@@ -9,6 +9,8 @@ module BulmaPhlex
   # integrating with Bulma's column and grid systems. The form control content is set via the
   # `control` method (or a block passed directly to the component).
   #
+  # If the label is passes as a string argument, the any additional html attributes can also be included as arguments.
+  #
   # ## References
   #
   # - [Bulma Form Field](https://bulma.io/documentation/form/general/#form-field)
@@ -46,8 +48,9 @@ module BulmaPhlex
     #
     # Optionally expects a block that renders a custom label (e.g. with a link or icon inside).
     # Only one of `label_string` or a block should be provided.
-    def label(label_string = nil, &block)
+    def label(label_string = nil, **html_attributes, &block)
       @label_string = label_string
+      @label_attributes = html_attributes
       @label_builder = block
     end
 
@@ -103,7 +106,7 @@ module BulmaPhlex
 
     def render_label
       if @label_string
-        html_label(class: "label") { @label_string }
+        html_label(**mix({ class: "label" }, **@label_attributes)) { @label_string }
       elsif @label_builder
         raw @label_builder&.call
       end

--- a/playground/sections/form_field_section.rb
+++ b/playground/sections/form_field_section.rb
@@ -6,10 +6,10 @@ module Playground
       def view_template
         h2(class: "title is-4") { "Form Field" }
 
-        h3(class: "subtitle is-6 mt-4") { "String Label + Help Text" }
+        h3(class: "subtitle is-6 mt-4") { "String Label with Attributes + Help Text" }
         div(class: "mb-5") do
           render BulmaPhlex::FormField.new(help: "We'll never share your email.") do |f|
-            f.label "Email"
+            f.label "Email", data: { controller: "label-help" }
             f.control { input(type: "email", class: "input", placeholder: "you@example.com") }
           end
         end

--- a/test/bulma_phlex/form_field_test.rb
+++ b/test/bulma_phlex/form_field_test.rb
@@ -52,6 +52,23 @@ module BulmaPhlex
       assert_html_equal expected_html, output
     end
 
+    def test_renders_label_from_string_with_html_attributes
+      component = FormField.new
+      output = component.call do |field|
+        field.label("Label from String", class: "extra", data: { value: "test" })
+        field.control { input_builder }
+      end
+
+      assert_html_equal <<~HTML, output
+        <div class="field">
+          <label class="label extra" data-value="test">Label from String</label>
+          <div class="control">
+            <input name="test_input" type="text" />
+          </div>
+        </div>
+      HTML
+    end
+
     def test_skips_label_when_not_provided
       component = FormField.new
       output = component.call do |field|


### PR DESCRIPTION
When passing the label in as a string argument, the method also accepts any additional html attributes.