### PR TITLE
Table: Responsive Columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,12 @@ To add pagination to the table, call `paginate` with a block that returns a path
 table.paginate { |page| products_path(page: page) }
 ```
 
+Hide columns on smaller screens with the column `hidden` option:
+
+```ruby
+table.column("Email", hidden: { mobile: true }) { |user| user.email }
+```
+
 
 ### Tabs
 

--- a/lib/bulma_phlex/table.rb
+++ b/lib/bulma_phlex/table.rb
@@ -8,24 +8,38 @@ module BulmaPhlex
   # (bordered, striped, hoverable) and **layout** options (narrow, fullwidth). An optional
   # **pagination** control can be added to the table footer via the `paginate` method.
   #
+  # To make the table responsive, use the `hidden` argument to hide certain columns on smaller
+  # screens. See the [Bulma documentation](https://bulma.io/documentation/helpers/visibility-helpers/#hide)
+  # for the full list, but the most common options are `hidden: "mobile"` and `hidden: "touch"`.
+  #
+  # The table supports any additional HTML attributes on the `<table>` element, such as `id` or `data-*`
+  # attributes, via the `**html_attributes` argument in the constructor.
+  #
   # ## Example
   #
   #     users = User.all
   #
   #     render BulmaPhlex::Table.new(users) do |table|
-  #       table.column "Name" do |user|
-  #         user.full_name
-  #       end
-  #
-  #       table.column "Email" do |user|
-  #         user.email
-  #       end
-  #
+  #       table.column("Name", &:full_name)
+  #       table.column("Email", hidden: "touch", &:email)
+  #       table.date_column("Joined", hidden: "mobile", &:created_at, format: "%B %d, %Y")
+  #       table.conditional_icon("Admin?", &:admin?)
   #       table.column "Actions" do |user|
   #         link_to "Edit", edit_user_path(user), class: "button is-small"
   #       end
   #     end
-  class Table < BulmaPhlex::Base
+  class Table < BulmaPhlex::Base # rubocop:disable Metrics/ClassLength
+    # Returns an array of CSS classes for the table based on the provided options.
+    def self.classes_for(bordered: false, striped: false, narrow: false, hoverable: false, fullwidth: false)
+      classes = ["table"]
+      classes << "is-bordered" if bordered
+      classes << "is-striped" if striped
+      classes << "is-narrow" if narrow
+      classes << "is-hoverable" if hoverable
+      classes << "is-fullwidth" if fullwidth
+      classes
+    end
+
     # **Parameters**
     #
     # - `rows` — The collection of records to display in the table
@@ -53,11 +67,7 @@ module BulmaPhlex
                    fullwidth: false,
                    **html_attributes)
       @rows = rows
-      @bordered = bordered
-      @striped = striped
-      @narrow = narrow
-      @hoverable = hoverable
-      @fullwidth = fullwidth
+      @table_classes = self.class.classes_for(bordered:, striped:, narrow:, hoverable:, fullwidth:)
       @html_attributes = html_attributes
       @columns = []
     end
@@ -65,19 +75,15 @@ module BulmaPhlex
     def view_template(&)
       vanish(&)
 
-      table(**mix({ class: table_classes }, @html_attributes)) do
+      table(**mix({ class: @table_classes }, @html_attributes)) do
         thead do
-          @columns.each do |column|
-            table_header(column)
-          end
+          @columns.each { |column| table_header(column) }
         end
 
         tbody do
           @rows.each do |row|
             tr do
-              @columns.each do |column|
-                td(**column[:html_attributes]) { column[:content].call(row) }
-              end
+              @columns.each { |column| table_data_cell(column, row) }
             end
           end
         end
@@ -92,8 +98,8 @@ module BulmaPhlex
     # - `**html_attributes` — Additional HTML attributes for each `<td>` cell in this column
     #
     # Expects a block that receives each `row` object and returns the cell content.
-    def column(header, **html_attributes, &content)
-      @columns << { header:, html_attributes:, content: }
+    def column(header, hidden: false, **html_attributes, &content)
+      @columns << { header:, hidden:, html_attributes:, content: }
     end
 
     # Adds a date-formatted column to the table. Can be called multiple times.
@@ -103,8 +109,8 @@ module BulmaPhlex
     # - `**html_attributes` — Additional HTML attributes for each `<td>` cell in this column
     #
     # Expects a block that receives each `row` object and returns a `Date` or `Time` value.
-    def date_column(header, format: "%Y-%m-%d", **html_attributes, &content)
-      column(header, **html_attributes) do |row|
+    def date_column(header, hidden: false, format: "%Y-%m-%d", **html_attributes, &content)
+      column(header, hidden:, **html_attributes) do |row|
         content.call(row)&.strftime(format)
       end
     end
@@ -116,10 +122,10 @@ module BulmaPhlex
     # - `**html_attributes` — Additional HTML attributes for each `<td>` cell in this column
     #
     # Expects a block that receives each `row` object and returns a truthy or falsy value.
-    def conditional_icon(header, icon_class: "fas fa-check", **html_attributes, &content)
+    def conditional_icon(header, hidden: false, icon_class: "fas fa-check", **html_attributes, &content)
       html_attributes[:class] = [html_attributes[:class], "has-text-centered"].compact.join(" ")
 
-      column(header, **html_attributes) do |row|
+      column(header, hidden:, **html_attributes) do |row|
         Icon(icon_class) if content.call(row)
       end
     end
@@ -134,33 +140,38 @@ module BulmaPhlex
 
     private
 
-    def table_classes
-      classes = ["table"]
-      classes << "is-bordered" if @bordered
-      classes << "is-striped" if @striped
-      classes << "is-narrow" if @narrow
-      classes << "is-hoverable" if @hoverable
-      classes << "is-fullwidth" if @fullwidth
-      classes
+    def table_header(column)
+      th(class: header_classes(column)) { column[:header] }
     end
 
-    # this derives a th class from the column html attributes
-    # perhaps a better way would be pre-defined pairs?
-    def table_header(column)
-      attributes = {}
-      attributes[:class] = header_alignment(column[:html_attributes])
-      th(**attributes) { column[:header] }
+    def header_classes(column)
+      classes = []
+      classes << "is-hidden-#{column[:hidden]}" if column[:hidden]
+      classes << header_alignment(column[:html_attributes])
+      classes.compact
     end
 
     def header_alignment(html_attributes)
       classes = html_attributes[:class]
       return if classes.nil?
 
-      if classes&.include?("has-text-right") || classes&.include?("amount-display")
+      if classes.include?("has-text-right") || classes.include?("amount-display")
         "has-text-right"
-      elsif classes&.include?("has-text-centered")
+      elsif classes.include?("has-text-centered")
         "has-text-centered"
       end
+    end
+
+    def table_data_cell(column, row)
+      td(**mix({ class: cell_classes(column) }, column[:html_attributes])) do
+        column[:content].call(row)
+      end
+    end
+
+    def cell_classes(column)
+      return unless column[:hidden]
+
+      "is-hidden-#{column[:hidden]}"
     end
 
     def pagination

--- a/test/bulma_phlex/table_test.rb
+++ b/test/bulma_phlex/table_test.rb
@@ -45,6 +45,32 @@ module BulmaPhlex
       assert_html_includes result, "<td>jane@example.com</td>"
     end
 
+    def test_adds_is_hidden_classes
+      rows = [
+        TestRecord.new(id: 1, name: "John Doe", email: "john@example.com"),
+        TestRecord.new(id: 2, name: "Jane Smith", email: "jane@example.com")
+      ]
+
+      component = BulmaPhlex::Table.new(rows)
+
+      raw_result = component.call do |table|
+        table.column("ID", &:id)
+        table.column("Name", &:name)
+        table.column("Email", hidden: "touch", &:email)
+      end
+
+      # Format the result for readable assertions and debugging
+      result = format_html(raw_result)
+
+      # Check for key elements in the rendered table
+      assert_html_includes result, "<th>ID</th>"
+      assert_html_includes result, "<th>Name</th>"
+      assert_html_includes result, '<th class="is-hidden-touch">Email</th>'
+      assert_html_includes result, "<td>1</td>"
+      assert_html_includes result, "<td>John Doe</td>"
+      assert_html_includes result, '<td class="is-hidden-touch">jane@example.com</td>'
+    end
+
     def test_renders_empty_table
       component = BulmaPhlex::Table.new([])
 
@@ -122,6 +148,18 @@ module BulmaPhlex
 
       assert_html_includes format_html(raw_result), 'data-test="value"'
       assert_html_includes format_html(raw_result), 'class="table projects"'
+    end
+
+    def test_classes_for_options
+      assert_equal ["table"], BulmaPhlex::Table.classes_for
+      assert_equal %w[table is-bordered], BulmaPhlex::Table.classes_for(bordered: true)
+      assert_equal %w[table is-striped], BulmaPhlex::Table.classes_for(striped: true)
+      assert_equal %w[table is-narrow], BulmaPhlex::Table.classes_for(narrow: true)
+      assert_equal %w[table is-hoverable], BulmaPhlex::Table.classes_for(hoverable: true)
+      assert_equal %w[table is-fullwidth], BulmaPhlex::Table.classes_for(fullwidth: true)
+
+      assert_equal %w[table is-bordered is-striped is-narrow],
+                   BulmaPhlex::Table.classes_for(bordered: true, striped: true, narrow: true)
     end
   end
 
@@ -201,6 +239,25 @@ module BulmaPhlex
       assert_html_includes result, '<td data-custom="go-bears">2023-10-01</td>'
       assert_html_includes result, '<td data-custom="go-bears">2023-10-02</td>'
     end
+
+    def test_date_column_with_hidden_option
+      rows = [
+        TestRecord.new(id: 1, name: "Event 1", start_date: Time.new(2023, 10, 1)),
+        TestRecord.new(id: 2, name: "Event 2", start_date: Time.new(2023, 10, 2))
+      ]
+
+      component = BulmaPhlex::Table.new(rows)
+
+      raw_result = component.call do |table|
+        table.date_column("Start Date", hidden: "mobile", &:start_date)
+      end
+
+      result = format_html(raw_result)
+
+      assert_html_includes result, '<th class="is-hidden-mobile">Start Date</th>'
+      assert_html_includes result, '<td class="is-hidden-mobile">2023-10-01</td>'
+      assert_html_includes result, '<td class="is-hidden-mobile">2023-10-02</td>'
+    end
   end
 
   class TableConditionalIconTest < Minitest::Test
@@ -248,6 +305,19 @@ module BulmaPhlex
       result = format_html(raw_result)
 
       assert_html_includes result, '<td class="has-text-centered"></td>'
+    end
+
+    def test_conditional_icon_column_with_hidden_option
+      row = [TestRecord.new(id: 1, name: "Item 1", active: true)]
+      component = BulmaPhlex::Table.new(row)
+
+      raw_result = component.call do |table|
+        table.conditional_icon("Active", hidden: "touch", icon_class: "fas fa-check", &:active)
+      end
+      result = format_html(raw_result)
+
+      assert_html_includes result, '<th class="is-hidden-touch has-text-centered">Active</th>'
+      assert_html_includes result, '<td class="is-hidden-touch has-text-centered">'
     end
   end
 end


### PR DESCRIPTION
This adds the ability to flag columns as hidden at certain breakpoints. The most common options here are `hidden: "mobile"` and `hidden: "touch"` (which means mobile and tablet).

The options-to-classes logic has been exposed. This pattern comes from the Button class and makes it available even if you are not using the Table component.