### PR TITLE
Bump minimum required Ruby to 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "3.2"
           - "3.3"
           - "3.4"
           - "4.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - ./tools/rubocop-bulma_phlex
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   NewCops: enable
 
 Gemspec/DevelopmentDependencies:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ gem install bulma-phlex
 
 This gem requires:
 
-- Ruby 3.2.10 or higher
+- Ruby 3.3 or higher
 - Phlex 2.4.1 or higher
 - Bulma CSS (which you'll need to include in your application)
 

--- a/bulma-phlex.gemspec
+++ b/bulma-phlex.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description = "Add Bulma components including Card, Level, NavigationBar, Pagination, Table, and Tabs " \
                      "to your Phlex application."
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.10"
+  spec.required_ruby_version = ">= 3.3"
 
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
Ruby 3.2 is EOL as of March 31, 2026. This bumps the minimum required ruby version to 3.3 and removes the 3.2 testing.