### PR TITLE
HTML Attributes on Table Row Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,13 @@ To add pagination to the table, call `paginate` with a block that returns a path
 table.paginate { |page| products_path(page: page) }
 ```
 
+Pass HTML attributes to the `tr` elements via the `row` method, using either keyword arguments or a block 
+that receives the record for the row:
+
+```ruby
+table.row(class: "custom-row-class") { |row| { id: "row-id-#{row.id}" } }
+```
+
 Hide columns on smaller screens with the column `hidden` option:
 
 ```ruby

--- a/lib/bulma_phlex/table.rb
+++ b/lib/bulma_phlex/table.rb
@@ -8,6 +8,9 @@ module BulmaPhlex
   # (bordered, striped, hoverable) and **layout** options (narrow, fullwidth). An optional
   # **pagination** control can be added to the table footer via the `paginate` method.
   #
+  # The `tr` elements can be customized with the `row` method, which accepts static HTML attributes
+  # and/or a block that generates dynamic attributes based on the row data.
+  #
   # To make the table responsive, use the `hidden` argument to hide certain columns on smaller
   # screens. See the [Bulma documentation](https://bulma.io/documentation/helpers/visibility-helpers/#hide)
   # for the full list, but the most common options are `hidden: "mobile"` and `hidden: "touch"`.
@@ -20,6 +23,7 @@ module BulmaPhlex
   #     users = User.all
   #
   #     render BulmaPhlex::Table.new(users) do |table|
+  #       table.row(class: "has-background-light") { |user| { id: "user-row-#{user.id}" } }
   #       table.column("Name", &:full_name)
   #       table.column("Email", hidden: "touch", &:email)
   #       table.date_column("Joined", hidden: "mobile", &:created_at, format: "%B %d, %Y")
@@ -82,7 +86,7 @@ module BulmaPhlex
 
         tbody do
           @rows.each do |row|
-            tr do
+            tr(**table_row_html_attributes(row)) do
               @columns.each { |column| table_data_cell(column, row) }
             end
           end
@@ -90,6 +94,11 @@ module BulmaPhlex
 
         pagination
       end
+    end
+
+    def row(**html_attributes, &attribute_builder)
+      @row_attributes = html_attributes
+      @row_attribute_builder = attribute_builder
     end
 
     # Adds a column to the table. Can be called multiple times to define all columns.
@@ -160,6 +169,15 @@ module BulmaPhlex
       elsif classes.include?("has-text-centered")
         "has-text-centered"
       end
+    end
+
+    def table_row_html_attributes(row)
+      attributes = @row_attributes || {}
+      if @row_attribute_builder
+        dynamic_attributes = @row_attribute_builder.call(row) || {}
+        attributes = attributes.merge(dynamic_attributes)
+      end
+      attributes
     end
 
     def table_data_cell(column, row)

--- a/test/bulma_phlex/table_test.rb
+++ b/test/bulma_phlex/table_test.rb
@@ -71,6 +71,71 @@ module BulmaPhlex
       assert_html_includes result, '<td class="is-hidden-touch">jane@example.com</td>'
     end
 
+    def test_html_attributes_on_table_row
+      rows = [
+        TestRecord.new(id: 1, name: "John Doe", email: "john@example.com"),
+        TestRecord.new(id: 2, name: "Jane Smith", email: "jane@example.com")
+      ]
+
+      component = BulmaPhlex::Table.new(rows)
+
+      raw_result = component.call do |table|
+        table.row(class: "custom-row-class")
+        table.column("ID", &:id)
+        table.column("Name", &:name)
+        table.column("Email", hidden: "touch", &:email)
+      end
+
+      # Format the result for readable assertions and debugging
+      result = format_html(raw_result)
+
+      assert_html_includes result, '<tr class="custom-row-class">'
+    end
+
+    def test_html_attributes_on_table_row_with_block
+      rows = [
+        TestRecord.new(id: 1, name: "John Doe", email: "john@example.com"),
+        TestRecord.new(id: 2, name: "Jane Smith", email: "jane@example.com")
+      ]
+
+      component = BulmaPhlex::Table.new(rows)
+
+      raw_result = component.call do |table|
+        table.row { |row| { id: "table-row-#{row.id}" } }
+        table.column("ID", &:id)
+        table.column("Name", &:name)
+        table.column("Email", hidden: "touch", &:email)
+      end
+
+      # Format the result for readable assertions and debugging
+      result = format_html(raw_result)
+
+      assert_html_includes result, '<tr id="table-row-1">'
+      assert_html_includes result, '<tr id="table-row-2">'
+    end
+
+    def test_html_attributes_on_table_row_with_args_and_block
+      rows = [
+        TestRecord.new(id: 1, name: "John Doe", email: "john@example.com"),
+        TestRecord.new(id: 2, name: "Jane Smith", email: "jane@example.com")
+      ]
+
+      component = BulmaPhlex::Table.new(rows)
+
+      raw_result = component.call do |table|
+        table.row(class: "custom-row-class") { |row| { id: "table-row-#{row.id}" } }
+        table.column("ID", &:id)
+        table.column("Name", &:name)
+        table.column("Email", hidden: "touch", &:email)
+      end
+
+      # Format the result for readable assertions and debugging
+      result = format_html(raw_result)
+
+      assert_html_includes result, '<tr class="custom-row-class" id="table-row-1">'
+      assert_html_includes result, '<tr class="custom-row-class" id="table-row-2">'
+    end
+
     def test_renders_empty_table
       component = BulmaPhlex::Table.new([])
 


### PR DESCRIPTION
This allows HTML attributes to be added to a table's `tr` elements. It can be a static list of attributes, or use a proc that receives the row to generate a hash.