### PR TITLE
Release 0.15.0: Bump min required ruby to 3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bulma-phlex (0.14.0)
+    bulma-phlex (0.15.0)
       phlex (>= 2.4.1)
 
 GEM

--- a/lib/bulma_phlex/version.rb
+++ b/lib/bulma_phlex/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BulmaPhlex
-  VERSION = "0.14.0"
+  VERSION = "0.15.0"
 end


### PR DESCRIPTION
This release bumps the minimum required Ruby to 3.3 and includes the following enhancements:

- Enable html attributes in FormField#label
- Responsive tables: hide columns on certain breakpoints
- Support html attributes on Table tr elements