### PR TITLE
Icon: HTML attributes for `i` element

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
@@ -224,4 +225,4 @@ CHECKSUMS
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 BUNDLED WITH
-   2.6.8
+  4.0.7

--- a/lib/bulma_phlex/icon.rb
+++ b/lib/bulma_phlex/icon.rb
@@ -5,7 +5,12 @@ module BulmaPhlex
   # form control positioning.
   #
   # Supports **color** and **size** options, optional **text** to the left or right of the icon,
-  # and **positioning** helpers (`left`/`right`) for use inside form controls.
+  # and **positioning** helpers (`left`/`right`) for use inside form controls. When text is provide,
+  # the icon and text are wrapped in a container with the `icon-text` class for proper spacing, and
+  # the icon includes `aria-hidden="true"` for accessibility.
+  #
+  # Additional HTML attributes can be passed to the icon's `<span>` element via `**html_attributes`,
+  # and to the inner `<i>` by nested them under `icon_attributes`.
   #
   # ## Example
   #
@@ -21,7 +26,8 @@ module BulmaPhlex
     # - `text_left` — Text to display to the left of the icon
     # - `left` — If `true`, adds the `is-left` class for use in form controls
     # - `right` — If `true`, adds the `is-right` class for use in form controls
-    # - `**html_attributes` — Additional HTML attributes for the icon span element
+    # - `**html_attributes` — Additional HTML attributes for the icon span element. Nest attributes under
+    #     `icon_attributes` to apply them to the inner `<i>` element instead.
     def self.new(icon,
                  text_right: nil,
                  text_left: nil,
@@ -48,14 +54,15 @@ module BulmaPhlex
       @color = color
       @left = left
       @right = right
-      @html_attributes = html_attributes
+      @html_attributes = html_attributes.clone
+      @icon_attributes = @html_attributes.delete(:icon_attributes) || {}
     end
 
     def view_template
       optional_text_wrapper do
         span { @text_left } if @text_left
         span(**mix({ class: icon_classes }, @html_attributes)) do
-          i(class: @icon)
+          i(class: @icon, **@icon_attributes)
         end
         span { @text_right } if @text_right
       end
@@ -65,10 +72,15 @@ module BulmaPhlex
 
     def optional_text_wrapper(&)
       if @text_right || @text_left
+        add_aria_hidden_to_icon_attributes
         span(class: "icon-text", &)
       else
         yield
       end
+    end
+
+    def add_aria_hidden_to_icon_attributes
+      @icon_attributes = mix({ aria: { hidden: "true" } }, @icon_attributes)
     end
 
     def icon_classes

--- a/test/bulma_phlex/icon_test.rb
+++ b/test/bulma_phlex/icon_test.rb
@@ -22,7 +22,7 @@ module BulmaPhlex
       assert_html_equal <<~HTML, result
         <span class="icon-text">
           <span class="icon">
-            <i class="fas fa-home"></i>
+            <i class="fas fa-home", aria-hidden="true"></i>
           </span>
           <span>Home</span>
         </span>
@@ -36,7 +36,7 @@ module BulmaPhlex
         <span class="icon-text">
           <span>Home</span>
           <span class="icon">
-            <i class="fas fa-home"></i>
+            <i class="fas fa-home" aria-hidden="true"></i>
           </span>
         </span>
       HTML
@@ -98,6 +98,16 @@ module BulmaPhlex
       assert_html_equal <<~HTML, result
         <span class="icon" id="home-icon" data-test="value">
           <i class="fas fa-home"></i>
+        </span>
+      HTML
+    end
+
+    def test_with_icon_attributes
+      result = Icon.new("fas fa-home", icon_attributes: { id: "home-icon", data: { test: "value" } }).call
+
+      assert_html_equal <<~HTML, result
+        <span class="icon">
+          <i class="fas fa-home" id="home-icon" data-test="value"></i>
         </span>
       HTML
     end


### PR DESCRIPTION
This adds the ability to provide HTML attributes for the inner `i` element. Additionally, by default it sets `aria-hidden="true"` when the icon is used with text.