### PR TITLE
Breadcrumb Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This gem provides a set of ready-to-use [Phlex](https://github.com/phlex-ruby/ph
 
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Breadcrumb](#breadcrumb)
   - [Button](#button)
   - [Card](#card)
   - [Columns](#columns)
@@ -77,6 +78,21 @@ require "bulma-phlex"
 ## Usage
 
 Use the Phlex components in your Rails views or any Ruby application that supports Phlex components.
+
+### Breadcrumb
+
+Renders a [Bulma breadcrumb](https://bulma.io/documentation/components/breadcrumb/) navigation element. Each breadcrumb item is added via the `item` method on the yielded component.
+
+```ruby
+render BulmaPhlex::Breadcrumb.new do |bc|
+  bc.item("Bulma", href: "/")
+  bc.item("Components", href: "/components")
+  bc.item("Breadcrumb")
+end
+```
+
+It supports options for **alignment** (centered, right-aligned), **separator** style (arrow, bullet, dot, or succeeds), and **size** (small, medium, large). Items also support an optional `icon` argument.
+
 
 ### Button
 

--- a/lib/bulma_phlex/breadcrumb.rb
+++ b/lib/bulma_phlex/breadcrumb.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  # Renders a [Bulma breadcrumb](https://bulma.io/documentation/components/breadcrumb/) component.
+  # It supports options for **alignment** (centered, right-aligned), **separator** style (arrow,
+  # bullet, dot, or succeeds (greater than)), and **size** (small, medium, large).
+  class Breadcrumb < Base
+    # **Parameters**
+    #
+    # - `align` — Breadcrumb alignment: `"centered"` or `"right"`
+    # - `separator` — Breadcrumb separator style: `"arrow"`, `"bullet"`, `"dot"`, or `"succeeds"`
+    # - `size` — Alternate size: `"small"`, `"medium"`, or `"large"`
+    # - `**html_attributes` — Additional HTML attributes for the `<nav>` element
+    def self.new(align: nil, separator: nil, size: nil, **html_attributes)
+      super
+    end
+
+    def initialize(align: nil, separator: nil, size: nil, **html_attributes)
+      @align = align
+      @separator = separator
+      @size = size
+      @html_attributes = html_attributes
+
+      @items = []
+    end
+
+    def view_template(&)
+      vanish(&)
+      return if @items.empty?
+
+      nav(**mix(@html_attributes, class: nav_classes, aria: { label: "breadcrumbs" })) do
+        ul do
+          @items[0...-1].each do |item|
+            render_item(item)
+          end
+
+          render_last_item
+        end
+      end
+    end
+
+    # Adds a breadcrumb item to the component. The last item added will be rendered as the active item.
+    #
+    # **Parameters**
+    # - `label` (positional) — The text label for the breadcrumb item
+    # - `href` — URL for the breadcrumb item; not required on last item / current page
+    # - `icon` — Optional icon class for the breadcrumb item (e.g. `"fa-solid fa-home"`)
+    def item(label, href: nil, icon: nil)
+      @items << { label:, icon:, html_attributes: { href: href } }
+    end
+
+    private
+
+    def nav_classes
+      classes = ["breadcrumb"]
+      classes << "is-#{@align}" if @align
+      classes << "has-#{@separator}-separator" if @separator
+      classes << "is-#{@size}" if @size
+      classes
+    end
+
+    def render_item(item, list_item_attributes: {})
+      li(**list_item_attributes) do
+        a(**item[:html_attributes]) do
+          if item[:icon]
+            render BulmaPhlex::Icon.new(item[:icon], size: "small", icon_attributes: { aria: { hidden: "true" } })
+            span { item[:label] }
+          else
+            plain item[:label]
+          end
+        end
+      end
+    end
+
+    def render_last_item
+      item = @items.last
+
+      item[:html_attributes] = mix(item[:html_attributes], aria: { current: "page" })
+      render_item(item, list_item_attributes: { class: "is-active" })
+    end
+  end
+end

--- a/playground/page.rb
+++ b/playground/page.rb
@@ -4,6 +4,7 @@ module Playground
   # This generates the playground for each component. Components must have a Section class and be registered here.
   class Page < Phlex::HTML
     SECTIONS = [
+      Sections::Breadcrumb,
       Sections::Button,
       Sections::Card,
       Sections::Columns,

--- a/playground/sections/breadcrumb_section.rb
+++ b/playground/sections/breadcrumb_section.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Playground
+  module Sections
+    class Breadcrumb < Phlex::HTML
+      def view_template
+        h2(class: "title is-4") { "Breadcrumb" }
+
+        render BulmaPhlex::Breadcrumb.new do |bc|
+          bc.item("Bulma", href: "/")
+          bc.item("Components", href: "/components")
+          bc.item("Breadcrumb")
+        end
+
+        h3(class: "subtitle is-5") { "Alignment" }
+        render BulmaPhlex::Breadcrumb.new(align: "centered") do |bc|
+          bc.item("Bulma", href: "/")
+          bc.item("Components", href: "/components")
+          bc.item("Breadcrumb")
+        end
+
+        render BulmaPhlex::Breadcrumb.new(align: "right") do |bc|
+          bc.item("Bulma", href: "/")
+          bc.item("Components", href: "/components")
+          bc.item("Breadcrumb")
+        end
+
+        h3(class: "subtitle is-5") { "Separator Style" }
+        render BulmaPhlex::Breadcrumb.new(separator: "arrow") do |bc|
+          bc.item("Bulma", href: "/")
+          bc.item("Components", href: "/components")
+          bc.item("Breadcrumb")
+        end
+
+        render BulmaPhlex::Breadcrumb.new(separator: "bullet") do |bc|
+          bc.item("Bulma", href: "/")
+          bc.item("Components", href: "/components")
+          bc.item("Breadcrumb")
+        end
+
+        render BulmaPhlex::Breadcrumb.new(separator: "dot") do |bc|
+          bc.item("Bulma", href: "/")
+          bc.item("Components", href: "/components")
+          bc.item("Breadcrumb")
+        end
+
+        render BulmaPhlex::Breadcrumb.new(separator: "succeeds") do |bc|
+          bc.item("Bulma", href: "/")
+          bc.item("Components", href: "/components")
+          bc.item("Breadcrumb")
+        end
+
+        h3(class: "subtitle is-5") { "Size" }
+        render BulmaPhlex::Breadcrumb.new(size: "small") do |bc|
+          bc.item("Bulma", href: "/")
+          bc.item("Components", href: "/components")
+          bc.item("Breadcrumb")
+        end
+
+        render BulmaPhlex::Breadcrumb.new(size: "medium") do |bc|
+          bc.item("Bulma", href: "/")
+          bc.item("Components", href: "/components")
+          bc.item("Breadcrumb")
+        end
+
+        render BulmaPhlex::Breadcrumb.new(size: "large") do |bc|
+          bc.item("Bulma", href: "/")
+          bc.item("Components", href: "/components")
+          bc.item("Breadcrumb")
+        end
+
+        h3(class: "subtitle is-5") { "With Icons" }
+        render BulmaPhlex::Breadcrumb.new do |bc|
+          bc.item("Home", href: "/", icon: "fas fa-home")
+          bc.item("Components", href: "/components", icon: "fas fa-cubes")
+          bc.item("Breadcrumb", icon: "fas fa-link")
+        end
+      end
+    end
+  end
+end

--- a/test/bulma_phlex/breadcrumb_test.rb
+++ b/test/bulma_phlex/breadcrumb_test.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module BulmaPhlex
+  class BreadcrumbTest < Minitest::Test
+    include TagOutputAssertions
+
+    def test_breadcrumb
+      component = BulmaPhlex::Breadcrumb.new
+      results = component.call do |bc|
+        bc.item("Bulma", href: "/")
+        bc.item("Components", href: "/components")
+        bc.item("Breadcrumb")
+      end
+
+      assert_html_equal <<~HTML, results
+        <nav class="breadcrumb" aria-label="breadcrumbs">
+          <ul>
+            <li><a href="/">Bulma</a></li>
+            <li><a href="/components">Components</a></li>
+            <li class="is-active"><a aria-current="page">Breadcrumb</a></li>
+          </ul>
+        </nav>
+      HTML
+    end
+
+    def test_single_item_breadcrumb
+      component = BulmaPhlex::Breadcrumb.new
+      results = component.call do |bc|
+        bc.item("Home", href: "/")
+      end
+
+      assert_html_equal <<~HTML, results
+        <nav class="breadcrumb" aria-label="breadcrumbs">
+          <ul>
+            <li class="is-active"><a href="/" aria-current="page">Home</a></li>
+          </ul>
+        </nav>
+      HTML
+    end
+
+    def test_align_centered
+      component = BulmaPhlex::Breadcrumb.new(align: "centered")
+      results = component.call do |bc|
+        bc.item("Bulma", href: "/")
+        bc.item("Components", href: "/components")
+        bc.item("Breadcrumb")
+      end
+
+      assert_html_equal <<~HTML, results
+        <nav class="breadcrumb is-centered" aria-label="breadcrumbs">
+          <ul>
+            <li><a href="/">Bulma</a></li>
+            <li><a href="/components">Components</a></li>
+            <li class="is-active"><a aria-current="page">Breadcrumb</a></li>
+          </ul>
+        </nav>
+      HTML
+    end
+
+    def test_align_right
+      component = BulmaPhlex::Breadcrumb.new(align: "right")
+      results = component.call do |bc|
+        bc.item("Bulma", href: "/")
+        bc.item("Components", href: "/components")
+        bc.item("Breadcrumb")
+      end
+
+      assert_html_includes results, 'class="breadcrumb is-right"'
+    end
+
+    def test_separator
+      component = BulmaPhlex::Breadcrumb.new(separator: "arrow")
+      results = component.call do |bc|
+        bc.item("Bulma", href: "/")
+        bc.item("Components", href: "/components")
+        bc.item("Breadcrumb")
+      end
+
+      assert_html_equal <<~HTML, results
+        <nav class="breadcrumb has-arrow-separator" aria-label="breadcrumbs">
+          <ul>
+            <li><a href="/">Bulma</a></li>
+            <li><a href="/components">Components</a></li>
+            <li class="is-active"><a aria-current="page">Breadcrumb</a></li>
+          </ul>
+        </nav>
+      HTML
+    end
+
+    def test_bullet_separator
+      component = BulmaPhlex::Breadcrumb.new(separator: "bullet")
+      results = component.call do |bc|
+        bc.item("Bulma", href: "/")
+        bc.item("Components", href: "/components")
+        bc.item("Breadcrumb")
+      end
+
+      assert_html_includes results, 'class="breadcrumb has-bullet-separator"'
+    end
+
+    def test_size_small
+      component = BulmaPhlex::Breadcrumb.new(size: "small")
+      results = component.call do |bc|
+        bc.item("Bulma", href: "/")
+        bc.item("Components", href: "/components")
+        bc.item("Breadcrumb")
+      end
+
+      assert_html_equal <<~HTML, results
+        <nav class="breadcrumb is-small" aria-label="breadcrumbs">
+          <ul>
+            <li><a href="/">Bulma</a></li>
+            <li><a href="/components">Components</a></li>
+            <li class="is-active"><a aria-current="page">Breadcrumb</a></li>
+          </ul>
+        </nav>
+      HTML
+    end
+
+    def test_size_large
+      component = BulmaPhlex::Breadcrumb.new(size: "large")
+      results = component.call do |bc|
+        bc.item("Bulma", href: "/")
+        bc.item("Components", href: "/components")
+        bc.item("Breadcrumb")
+      end
+
+      assert_html_includes results, 'class="breadcrumb is-large"'
+    end
+
+    def test_with_icons
+      component = BulmaPhlex::Breadcrumb.new
+      results = component.call do |bc|
+        bc.item("Bulma", href: "/", icon: "fas fa-home")
+        bc.item("Components", href: "/components", icon: "fas fa-puzzle-piece")
+        bc.item("Breadcrumb", icon: "fas fa-thumbs-up")
+      end
+
+      assert_html_equal <<~HTML, results
+        <nav class="breadcrumb" aria-label="breadcrumbs">
+          <ul>
+            <li>
+              <a href="/">
+                <span class="icon is-small">
+                  <i class="fas fa-home" aria-hidden="true"></i>
+                </span>
+                <span>Bulma</span>
+              </a>
+            </li>
+            <li>
+              <a href="/components">
+                <span class="icon is-small">
+                  <i class="fas fa-puzzle-piece" aria-hidden="true"></i>
+                </span>
+                <span>Components</span>
+              </a>
+            </li>
+            <li class="is-active">
+              <a aria-current="page">
+                <span class="icon is-small">
+                  <i class="fas fa-thumbs-up" aria-hidden="true"></i>
+                </span>
+                <span>Breadcrumb</span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      HTML
+    end
+
+    def test_additional_html_attributes
+      component = BulmaPhlex::Breadcrumb.new(data: { test: "breadcrumb-component" })
+      results = component.call do |bc|
+        bc.item("Bulma", href: "/")
+        bc.item("Components", href: "/components")
+        bc.item("Breadcrumb")
+      end
+
+      assert_html_includes results, 'data-test="breadcrumb-component"'
+    end
+  end
+end


### PR DESCRIPTION
This adds the Breadcrump component, with options for size, separators, alignment, and icons.

<img width="390" height="48" alt="image" src="https://github.com/user-attachments/assets/aea69ee1-2fdd-4270-acba-4af925667a7d" />
