### PR TITLE
Navigation Bar Dropdown Header Enhancements

### DIFF
--- a/lib/bulma_phlex/navigation_bar_dropdown.rb
+++ b/lib/bulma_phlex/navigation_bar_dropdown.rb
@@ -26,8 +26,11 @@ module BulmaPhlex
       div(class: "navbar-dropdown is-right", &)
     end
 
-    def header(label)
-      div(class: "navbar-item header has-text-weight-medium") { label }
+    # Adds a non-clickable header item to the dropdown menu. Optionally add a divider before the header with
+    # the `divder: true` parameter.
+    def header(label, divider: false)
+      self.divider if divider
+      div(class: "navbar-item has-text-weight-semibold") { label }
     end
 
     def item(label, path)

--- a/test/bulma_phlex/navigation_bar_dropdown_test.rb
+++ b/test/bulma_phlex/navigation_bar_dropdown_test.rb
@@ -18,7 +18,7 @@ module BulmaPhlex
 
       expected_html = <<~HTML
         <div class="navbar-dropdown is-right">
-          <div class="navbar-item header has-text-weight-medium">User</div>
+          <div class="navbar-item has-text-weight-semibold">User</div>
           <a class="navbar-item" href="/profile">Profile</a>
           <hr class="navbar-divider">
           <a class="navbar-item" href="/logout">Sign Out</a>
@@ -53,9 +53,30 @@ module BulmaPhlex
         dropdown.item("Item 2", "/item2")
       end
 
-      assert_html_includes result, '<div class="navbar-item header has-text-weight-medium">Section 1</div>'
+      assert_html_includes result, '<div class="navbar-item has-text-weight-semibold">Section 1</div>'
       assert_html_includes result, '<hr class="navbar-divider">'
-      assert_html_includes result, '<div class="navbar-item header has-text-weight-medium">Section 2</div>'
+      assert_html_includes result, '<div class="navbar-item has-text-weight-semibold">Section 2</div>'
+    end
+
+    def test_renders_optional_divider_on_headers
+      component = BulmaPhlex::NavigationBarDropdown.new
+
+      result = component.call do |dropdown|
+        dropdown.header("Section 1")
+        dropdown.item("Item 1", "/item1")
+        dropdown.header("Section 2", divider: true)
+        dropdown.item("Item 2", "/item2")
+      end
+
+      assert_html_equal <<~HTML, result
+        <div class="navbar-dropdown is-right">
+          <div class="navbar-item has-text-weight-semibold">Section 1</div>
+          <a class="navbar-item" href="/item1">Item 1</a>
+          <hr class="navbar-divider">
+          <div class="navbar-item has-text-weight-semibold">Section 2</div>
+          <a class="navbar-item" href="/item2">Item 2</a>
+        </div>
+      HTML
     end
   end
 end


### PR DESCRIPTION
This removes the `header` class from the header and changes the text class from has-text-weight-medium to has-text-weight-semibold.

Additionally this adds an optional `divider` argument to the header to make it easy to add a divider above a header.