### PR TITLE
Card Enhancements and Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Renders a [Bulma card](https://bulma.io/documentation/components/card/) with an 
 
 ```ruby
 render BulmaPhlex::Card.new do |card|
-  card.head("Card Title")
+  card.header("Card Title")
   card.image(src: "image.jpg", alt: "Card image")
   card.content do
     "This is some card content"
@@ -124,6 +124,8 @@ render BulmaPhlex::Card.new do |card|
   card.footer_link("Edit", "/edit", icon: "fas fa-edit")
 end
 ```
+
+The `header` method accepts a string, for a simple title, or a block for custom content.
 
 Use method `footer_item` for full control of the footer items. Class `footer-item` must be on the outer element 
 of the block.

--- a/README.md
+++ b/README.md
@@ -111,11 +111,12 @@ The button label can be passed in as a string or in a block.
 
 ### Card
 
-Renders a [Bulma card](https://bulma.io/documentation/components/card/) with an optional header, content area, and footer links. Each section is populated via builder methods on the yielded component.
+Renders a [Bulma card](https://bulma.io/documentation/components/card/) with an optional header, image, content area, and footer links. Each section is populated via builder methods on the yielded component.
 
 ```ruby
 render BulmaPhlex::Card.new do |card|
   card.head("Card Title")
+  card.image(src: "image.jpg", alt: "Card image")
   card.content do
     "This is some card content"
   end

--- a/lib/bulma_phlex/card.rb
+++ b/lib/bulma_phlex/card.rb
@@ -3,7 +3,7 @@
 module BulmaPhlex
   # Renders a [Bulma card](https://bulma.io/documentation/components/card/) component.
   #
-  # Supports an optional **header** (with title and custom classes), a **content** area, and a
+  # Supports an optional **header** (with title and custom classes), an **image**, a **content** area, and a
   # **footer** with one or more link items (which can include icons). Each section is populated
   # via builder methods on the yielded component.
   #
@@ -34,6 +34,7 @@ module BulmaPhlex
 
       div(**mix(class: "card", **@html_attributes)) do
         card_header
+        card_image
         card_content
         card_footer
       end
@@ -46,6 +47,10 @@ module BulmaPhlex
     def head(title, classes: nil)
       @header_title = title
       @header_classes = classes
+    end
+
+    def image(src:, alt: nil, size: nil, rounded: false)
+      @image = BulmaPhlex::Image.new(src:, alt:, size:, rounded:)
     end
 
     # Sets the card body content.
@@ -78,6 +83,14 @@ module BulmaPhlex
 
       header(class: "card-header #{@header_classes}") do
         p(class: "card-header-title") { plain @header_title }
+      end
+    end
+
+    def card_image
+      return if @image.nil?
+
+      div(class: "card-image") do
+        render @image
       end
     end
 

--- a/lib/bulma_phlex/card.rb
+++ b/lib/bulma_phlex/card.rb
@@ -18,6 +18,8 @@ module BulmaPhlex
   #       card.footer_link("Edit", "/edit", class: "has-text-primary")
   #     end
   class Card < BulmaPhlex::Base
+    extend Gem::Deprecate
+
     # **Parameters**
     #
     # - `**html_attributes` — Additional HTML attributes for the card element
@@ -45,8 +47,24 @@ module BulmaPhlex
     # - `title` — The text to display in the card header
     # - `classes` — Optional additional CSS classes for the header element
     def head(title, classes: nil)
+      header(title, class: classes)
+    end
+
+    deprecate :head, :header, 2027, 1
+
+    # in order to use the method name `header`, we need to grab a reference to the method on the base class
+    # so it is still available to us
+    alias html_header header
+
+    # Sets the card header. Pass in the title as a string and/or provide a block to render custom content
+    # in the header.
+    #
+    # - `title` — The text to display in the card header (optional)
+    # - `**html_attributes` — Additional HTML attributes for the header element (optional)
+    def header(title = nil, **html_attributes, &block)
       @header_title = title
-      @header_classes = classes
+      @header_attributes = html_attributes
+      @header_content = block
     end
 
     def image(src:, alt: nil, size: nil, rounded: false)
@@ -79,10 +97,11 @@ module BulmaPhlex
     private
 
     def card_header
-      return if @header_title.nil?
+      return if @header_title.nil? && @header_content.nil?
 
-      header(class: "card-header #{@header_classes}") do
-        p(class: "card-header-title") { plain @header_title }
+      html_header(**mix({ class: "card-header" }, @header_attributes)) do
+        p(class: "card-header-title") { plain @header_title } if @header_title
+        @header_content&.call
       end
     end
 

--- a/lib/bulma_phlex/card.rb
+++ b/lib/bulma_phlex/card.rb
@@ -85,7 +85,7 @@ module BulmaPhlex
       return if @card_content.nil?
 
       div(class: "card-content") do
-        div(class: "content") { @card_content.call }
+        @card_content.call
       end
     end
 

--- a/playground/sections/card_section.rb
+++ b/playground/sections/card_section.rb
@@ -16,6 +16,17 @@ module Playground
           end
         end
 
+        h3(class: "label") { "With Image" }
+        div(class: "mb-5") do
+          render BulmaPhlex::Card.new do |card|
+            card.image(src: "https://bulma.io/assets/images/placeholders/1280x960.png")
+            card.content do
+              plain "The image can be used for a profile picture, product image, or any other visual representation " \
+                    "related to the card content."
+            end
+          end
+        end
+
         h3(class: "label") { "With Footer Links" }
         div(class: "mb-5") do
           render BulmaPhlex::Card.new do |card|

--- a/test/bulma_phlex/card_test.rb
+++ b/test/bulma_phlex/card_test.rb
@@ -10,7 +10,7 @@ module BulmaPhlex
       component = BulmaPhlex::Card.new
 
       result = component.call do |card|
-        card.head("Card Title")
+        card.header("Card Title")
         card.content do
           "This is some card content"
         end
@@ -19,7 +19,7 @@ module BulmaPhlex
 
       expected_html = <<~HTML
         <div class="card">
-          <header class="card-header ">
+          <header class="card-header">
             <p class="card-header-title">Card Title</p>
           </header>
           <div class="card-content">
@@ -38,7 +38,9 @@ module BulmaPhlex
       component = BulmaPhlex::Card.new
 
       result = component.call do |card|
-        card.head("Custom Header", classes: "is-primary")
+        Gem::Deprecate.skip_during do
+          card.head("Custom Header", classes: "is-primary")
+        end
       end
 
       expected_html = <<~HTML
@@ -50,6 +52,81 @@ module BulmaPhlex
       HTML
 
       assert_html_equal expected_html, result
+    end
+
+    def test_header_with_title
+      component = BulmaPhlex::Card.new
+
+      result = component.call do |card|
+        card.header("Card Header")
+      end
+
+      expected_html = <<~HTML
+        <div class="card">
+          <header class="card-header">
+            <p class="card-header-title">Card Header</p>
+          </header>
+        </div>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_header_with_additional_attributes
+      component = BulmaPhlex::Card.new
+
+      result = component.call do |card|
+        card.header("Card Header", class: "is-primary", data: { test: "value" })
+      end
+
+      expected_html = <<~HTML
+        <div class="card">
+          <header class="card-header is-primary" data-test="value">
+            <p class="card-header-title">Card Header</p>
+          </header>
+        </div>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_header_with_block
+      component = BulmaPhlex::Card.new
+
+      result = component.call do |card|
+        card.header do
+          card.p(class: "card-header-title sale") { "On Sale" }
+        end
+      end
+
+      expected_html = <<~HTML
+        <div class="card">
+          <header class="card-header">
+            <p class="card-header-title sale">On Sale</p>
+          </header>
+        </div>
+      HTML
+
+      assert_html_equal expected_html, result
+    end
+
+    def test_header_with_title_and_block
+      component = BulmaPhlex::Card.new
+
+      result = component.call do |card|
+        card.header("Card Header") do
+          card.p(class: "subtitle") { "On Sale" }
+        end
+      end
+
+      assert_html_equal <<~HTML, result
+        <div class="card">
+          <header class="card-header">
+            <p class="card-header-title">Card Header</p>
+            <p class="subtitle">On Sale</p>
+          </header>
+        </div>
+      HTML
     end
 
     def test_with_image
@@ -119,12 +196,12 @@ module BulmaPhlex
       component = BulmaPhlex::Card.new(id: "my-card", data: { test: "value" })
 
       result = component.call do |card|
-        card.head("Card with Attributes")
+        card.header("Card with Attributes")
       end
 
       expected_html = <<~HTML
         <div class="card" id="my-card" data-test="value">
-          <header class="card-header ">
+          <header class="card-header">
             <p class="card-header-title">Card with Attributes</p>
           </header>
         </div>

--- a/test/bulma_phlex/card_test.rb
+++ b/test/bulma_phlex/card_test.rb
@@ -52,6 +52,24 @@ module BulmaPhlex
       assert_html_equal expected_html, result
     end
 
+    def test_with_image
+      component = BulmaPhlex::Card.new
+
+      result = component.call do |card|
+        card.image(src: "image.jpg", alt: "An image", size: 128, rounded: true)
+      end
+
+      assert_html_equal <<~HTML, result
+        <div class="card">
+          <div class="card-image">
+            <figure class="image is-128x128">
+              <img src="image.jpg" alt="An image" class="is-rounded"/>
+            </figure>
+          </div>
+        </div>
+      HTML
+    end
+
     def test_footer_with_links
       component = BulmaPhlex::Card.new
 

--- a/test/bulma_phlex/card_test.rb
+++ b/test/bulma_phlex/card_test.rb
@@ -23,7 +23,7 @@ module BulmaPhlex
             <p class="card-header-title">Card Title</p>
           </header>
           <div class="card-content">
-            <div class="content">This is some card content</div>
+            This is some card content
           </div>
           <footer class="card-footer">
             <a href="/footer-link" class="card-footer-item">Footer Link</a>


### PR DESCRIPTION
The following updates have been made to the card component:

- Do not wrap the content block with a `content` div. It was a pretty specific use case, and does not make sense as the default. If needed, it can be added back inside the block manually.
- Support the image section.
- Allow blocks for the header. This also introduces the method name `header` (which matches the section) and deprecates the existing `head` method. The new method also uses the same capture of HTML attributes that is standard across the library.