### PR TITLE
Handle additional classes in Card constructor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem "rake", "~> 13.0"
 gem "minitest", "~> 6.0"
 
 gem "rubocop", "~> 1.21"
+gem "ruby-lsp", "~> 0.26"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,10 @@ GEM
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.4.2)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -133,6 +137,10 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    ruby-lsp (0.26.10)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 1.2, < 2.0)
+      rbs (>= 3, < 5)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     stringio (3.2.0)
@@ -159,6 +167,7 @@ DEPENDENCIES
   minitest-difftastic
   rake (~> 13.0)
   rubocop (~> 1.21)
+  ruby-lsp (~> 0.26)
 
 CHECKSUMS
   actionpack (8.1.3) sha256=af998cae4d47c5d581a2cc363b5c77eb718b7c4b45748d81b1887b25621c29a3
@@ -207,12 +216,14 @@ CHECKSUMS
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   refract (1.1.0) sha256=ee3b9627e39f7692831101e2fedd73e0d09a592ff5d5c05f171d14211fc7a9c7
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rubocop (1.88.0) sha256=e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  ruby-lsp (0.26.10) sha256=e67284af94423531f6b9a583350596421b5a6a4dd93083f1c2ba03da7c23bbed
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1

--- a/lib/bulma_phlex/card.rb
+++ b/lib/bulma_phlex/card.rb
@@ -34,7 +34,7 @@ module BulmaPhlex
     def view_template(&)
       vanish(&)
 
-      div(**mix(class: "card", **@html_attributes)) do
+      div(**mix({ class: "card" }, **@html_attributes)) do
         card_header
         card_image
         card_content

--- a/test/bulma_phlex/card_test.rb
+++ b/test/bulma_phlex/card_test.rb
@@ -210,6 +210,21 @@ module BulmaPhlex
       assert_html_equal expected_html, result
     end
 
+    def test_with_additional_classes
+      component = BulmaPhlex::Card.new(class: "approved")
+      result = component.call do |card|
+        card.header("Card with Additional Classes")
+      end
+
+      assert_html_equal <<~HTML, result
+        <div class="card approved">
+          <header class="card-header">
+            <p class="card-header-title">Card with Additional Classes</p>
+          </header>
+        </div>
+      HTML
+    end
+
     def test_footer_items
       component = BulmaPhlex::Card.new
 


### PR DESCRIPTION
The additional HTML attributes for the Card component uses the Phlex method `mix` to
merge the attributes. That method requires the starting attributes to be a hash,
which the Card component was not using.

There are no other instances of the incorrect calling of `mix`.