### PR TITLE
Use warn for deprecation instead of Gem::Deprecate

### DIFF
--- a/lib/bulma_phlex/card.rb
+++ b/lib/bulma_phlex/card.rb
@@ -18,8 +18,6 @@ module BulmaPhlex
   #       card.footer_link("Edit", "/edit", class: "has-text-primary")
   #     end
   class Card < BulmaPhlex::Base
-    extend Gem::Deprecate
-
     # **Parameters**
     #
     # - `**html_attributes` — Additional HTML attributes for the card element
@@ -47,10 +45,10 @@ module BulmaPhlex
     # - `title` — The text to display in the card header
     # - `classes` — Optional additional CSS classes for the header element
     def head(title, classes: nil)
+      warn "[DEPRECATION] `BulmaPhlex::Card#head` is deprecated. Use `header` instead.", category: :deprecated
+
       header(title, class: classes)
     end
-
-    deprecate :head, :header, 2027, 1
 
     # in order to use the method name `header`, we need to grab a reference to the method on the base class
     # so it is still available to us

--- a/test/bulma_phlex/card_test.rb
+++ b/test/bulma_phlex/card_test.rb
@@ -38,9 +38,11 @@ module BulmaPhlex
       component = BulmaPhlex::Card.new
 
       result = component.call do |card|
-        Gem::Deprecate.skip_during do
-          card.head("Custom Header", classes: "is-primary")
-        end
+        deprecated_warning_flag = Warning[:deprecated]
+        Warning[:deprecated] = false
+        card.head("Custom Header", classes: "is-primary")
+      ensure
+        Warning[:deprecated] = deprecated_warning_flag
       end
 
       expected_html = <<~HTML


### PR DESCRIPTION
The Gem::Deprecate#deprecate method calls `format` without the Kernel namespace, which causes it to throw an error because Phlex components also implement the method.

The removes Gem::Deprecate in favor of a simple call to `warn`.

---

https://github.com/ruby/rubygems/issues/9704