### PR TITLE
Navigation Bar Dropdown Enhancements

### DIFF
--- a/lib/bulma_phlex/navigation_bar_dropdown.rb
+++ b/lib/bulma_phlex/navigation_bar_dropdown.rb
@@ -3,12 +3,16 @@
 module BulmaPhlex
   # Renders a dropdown menu for the [Bulma navbar](https://bulma.io/documentation/components/navbar/#dropdown-menu).
   #
-  # Provides structured content for a navbar dropdown, including **headers**, **links**, and **dividers**.
-  # Intended to be used inside a {BulmaPhlex::NavigationBar} block.
+  # Provides structured content for a navbar dropdown, including **headers**, **links**, and **dividers**. Pass boolean
+  # flags `right` or `boxed` to the constructor to customize the dropdown. This component is intended to be used inside
+  # a {BulmaPhlex::NavigationBar} block.
+  #
+  # The constructor and each of the three methods (`header`, `item`, and `divider`) can accept additional HTML
+  # attributes.
   #
   # ## Example
   #
-  #     render BulmaPhlex::NavigationBar.new do |navbar|
+  #     render BulmaPhlex::NavigationBar.new(right: true) do |navbar|
   #       navbar.brand_item "My App", "/"
   #
   #       navbar.right do |menu|
@@ -17,28 +21,56 @@ module BulmaPhlex
   #           dropdown.item "Profile", "/profile"
   #           dropdown.item "Settings", "/settings"
   #           dropdown.divider
-  #           dropdown.item "Sign Out", "/logout"
+  #           dropdown.item "Sign Out", "/logout", data: { turbo_prefetch: "false" }
   #         end
   #       end
   #     end
   class NavigationBarDropdown < BulmaPhlex::Base
+    # **Parameters**
+    #
+    # - `right` — If `true`, aligns the dropdown to the right side of the navbar
+    # - `boxed` — If `true`, applies the Bulma `is-boxed` style to the dropdown
+    # - `**html_attributes` — Additional HTML attributes for the dropdown container
+    def self.new(right: false, boxed: false, **html_attributes)
+      super
+    end
+
+    def initialize(right: false, boxed: false, **html_attributes)
+      @right = right
+      @boxed = boxed
+      @html_attributes = html_attributes
+    end
+
     def view_template(&)
-      div(class: "navbar-dropdown is-right", &)
+      div(**mix({ class: navbar_dropdown_classes }, @html_attributes), &)
     end
 
     # Adds a non-clickable header item to the dropdown menu. Optionally add a divider before the header with
     # the `divder: true` parameter.
-    def header(label, divider: false)
+    def header(label, divider: false, **html_attributes)
       self.divider if divider
-      div(class: "navbar-item has-text-weight-semibold") { label }
+
+      attributes = mix({ class: "navbar-item has-text-weight-semibold" }, html_attributes)
+      div(**attributes) { label }
     end
 
-    def item(label, path)
-      a(class: "navbar-item", href: path) { label }
+    def item(label, path, **html_attributes)
+      attributes = mix({ class: "navbar-item", href: path }, html_attributes)
+      a(**attributes) { label }
     end
 
-    def divider
-      hr(class: "navbar-divider")
+    def divider(**html_attributes)
+      attributes = mix({ class: "navbar-divider" }, html_attributes)
+      hr(**attributes)
+    end
+
+    private
+
+    def navbar_dropdown_classes
+      classes = ["navbar-dropdown"]
+      classes << "is-right" if @right
+      classes << "is-boxed" if @boxed
+      classes.join(" ")
     end
   end
 end

--- a/test/bulma_phlex/navigation_bar_dropdown_test.rb
+++ b/test/bulma_phlex/navigation_bar_dropdown_test.rb
@@ -17,7 +17,7 @@ module BulmaPhlex
       end
 
       expected_html = <<~HTML
-        <div class="navbar-dropdown is-right">
+        <div class="navbar-dropdown">
           <div class="navbar-item has-text-weight-semibold">User</div>
           <a class="navbar-item" href="/profile">Profile</a>
           <hr class="navbar-divider">
@@ -69,7 +69,7 @@ module BulmaPhlex
       end
 
       assert_html_equal <<~HTML, result
-        <div class="navbar-dropdown is-right">
+        <div class="navbar-dropdown">
           <div class="navbar-item has-text-weight-semibold">Section 1</div>
           <a class="navbar-item" href="/item1">Item 1</a>
           <hr class="navbar-divider">
@@ -77,6 +77,75 @@ module BulmaPhlex
           <a class="navbar-item" href="/item2">Item 2</a>
         </div>
       HTML
+    end
+
+    def test_with_right_aligned_dropdown
+      component = BulmaPhlex::NavigationBarDropdown.new(right: true)
+
+      result = component.call do |dropdown|
+        dropdown.header("Section 1")
+        dropdown.item("Item 1", "/item1")
+      end
+
+      assert_html_includes result, '<div class="navbar-dropdown is-right">'
+    end
+
+    def test_with_boxed_dropdown
+      component = BulmaPhlex::NavigationBarDropdown.new(boxed: true)
+
+      result = component.call do |dropdown|
+        dropdown.header("Section 1")
+        dropdown.item("Item 1", "/item1")
+      end
+
+      assert_html_includes result, '<div class="navbar-dropdown is-boxed">'
+    end
+
+    def test_with_html_attributes_on_dropdown
+      component = BulmaPhlex::NavigationBarDropdown.new(data: { foo: "bar" }, id: "my-dropdown")
+
+      result = component.call do |dropdown|
+        dropdown.header("Section 1")
+        dropdown.item("Item 1", "/item1")
+      end
+
+      assert_html_includes result, '<div class="navbar-dropdown" data-foo="bar" id="my-dropdown">'
+    end
+
+    def test_header_with_html_attributes
+      component = BulmaPhlex::NavigationBarDropdown.new
+
+      result = component.call do |dropdown|
+        dropdown.header("Section 1", class: "custom-header")
+        dropdown.header("Section 2", data: { foo: "bar" })
+      end
+
+      assert_html_includes result, '<div class="navbar-item has-text-weight-semibold custom-header">Section 1</div>'
+      assert_html_includes result, '<div class="navbar-item has-text-weight-semibold" data-foo="bar">Section 2</div>'
+    end
+
+    def test_item_with_html_attributes
+      component = BulmaPhlex::NavigationBarDropdown.new
+
+      result = component.call do |dropdown|
+        dropdown.item("Item 1", "/item1", class: "custom-class")
+        dropdown.item("Item 2", "/item2", data: { foo: "bar" })
+      end
+
+      assert_html_includes result, '<a class="navbar-item custom-class" href="/item1">Item 1</a>'
+      assert_html_includes result, '<a class="navbar-item" href="/item2" data-foo="bar">Item 2</a>'
+    end
+
+    def test_divider_with_html_attributes
+      component = BulmaPhlex::NavigationBarDropdown.new
+
+      result = component.call do |dropdown|
+        dropdown.divider(class: "custom-divider")
+        dropdown.divider(data: { foo: "bar" })
+      end
+
+      assert_html_includes result, '<hr class="navbar-divider custom-divider">'
+      assert_html_includes result, '<hr class="navbar-divider" data-foo="bar">'
     end
   end
 end


### PR DESCRIPTION
This updates the Navigation Bar Dropdown component to accept additional options and HTML attributes. The constructor now accepts boolean flags `right` and `boxed` to add the related classes (`is-right`, `is-boxed`) to the container div.

Note: This represents a change. Previously right was assumed and the `is-right` class
was always present. To keep existing behavior, add `right: true` to the call.

Additionally, the constructor and the three methods (`header`, `item`, and `divider`) now accept HTML attributes.

One example usage is to pass `data: { turbo_prefetch: "false" }` to any sign out links.