### PR TITLE
Modal Component: Enable custom Stimulus controller name

### DIFF
--- a/lib/bulma_phlex/modal.rb
+++ b/lib/bulma_phlex/modal.rb
@@ -8,7 +8,12 @@ module BulmaPhlex
   # `data_attributes_builder` option.
   class Modal < BulmaPhlex::Base
     StimulusDataAttributes = Data.define(:stimulus_controller) do
-      def for_container = { controller: stimulus_controller }
+      def for_container
+        { controller: stimulus_controller,
+          action: ["keydown.esc@document->#{stimulus_controller}#close",
+                   "command->#{stimulus_controller}#openOrCloseByCommand"] }
+      end
+
       def for_background = { action: "click->#{stimulus_controller}#close" }
       def for_close_button = { action: "#{stimulus_controller}#close" }
     end

--- a/lib/bulma_phlex/modal.rb
+++ b/lib/bulma_phlex/modal.rb
@@ -9,8 +9,8 @@ module BulmaPhlex
   class Modal < BulmaPhlex::Base
     StimulusDataAttributes = Data.define(:stimulus_controller) do
       def for_container = { controller: stimulus_controller }
-      def for_background = { action: "click->bulma-phlex--modal#close" }
-      def for_close_button = { action: "bulma-phlex--modal#close" }
+      def for_background = { action: "click->#{stimulus_controller}#close" }
+      def for_close_button = { action: "#{stimulus_controller}#close" }
     end
 
     # **Parameters**

--- a/test/bulma_phlex/modal_test.rb
+++ b/test/bulma_phlex/modal_test.rb
@@ -39,5 +39,24 @@ module BulmaPhlex
         </div>
       HTML
     end
+
+    def test_with_custom_stimulus_controller
+      data_attributes_builder = BulmaPhlex::Modal::StimulusDataAttributes.new("rockridge--mc")
+      component = BulmaPhlex::Modal.new(data_attributes_builder:)
+
+      result = component.call do
+        "Modal content goes here"
+      end
+
+      assert_html_equal <<~HTML, result
+        <div class="modal" data-controller="rockridge--mc">
+          <div class="modal-background" data-action="click->rockridge--mc#close"></div>
+          <div class="modal-content">
+            Modal content goes here
+          </div>
+          <button class="modal-close is-large" aria-label="close" data-action="rockridge--mc#close"></button>
+        </div>
+      HTML
+    end
   end
 end

--- a/test/bulma_phlex/modal_test.rb
+++ b/test/bulma_phlex/modal_test.rb
@@ -13,7 +13,7 @@ module BulmaPhlex
       end
 
       assert_html_equal <<~HTML, result
-        <div class="modal" data-controller="bulma-phlex--modal">
+        <div class="modal" data-controller="bulma-phlex--modal" data-action="keydown.esc@document->bulma-phlex--modal#close command->bulma-phlex--modal#openOrCloseByCommand">
           <div class="modal-background" data-action="click->bulma-phlex--modal#close"></div>
           <div class="modal-content">
             Modal content goes here
@@ -30,7 +30,7 @@ module BulmaPhlex
       end
 
       assert_html_equal <<~HTML, result
-        <div class="modal is-active" data-controller="bulma-phlex--modal" data-test="value">
+        <div class="modal is-active" data-controller="bulma-phlex--modal" data-action="keydown.esc@document->bulma-phlex--modal#close command->bulma-phlex--modal#openOrCloseByCommand" data-test="value">
           <div class="modal-background" data-action="click->bulma-phlex--modal#close"></div>
           <div class="modal-content">
             Active modal content
@@ -49,7 +49,7 @@ module BulmaPhlex
       end
 
       assert_html_equal <<~HTML, result
-        <div class="modal" data-controller="rockridge--mc">
+        <div class="modal" data-controller="rockridge--mc" data-action="keydown.esc@document->rockridge--mc#close command->rockridge--mc#openOrCloseByCommand">
           <div class="modal-background" data-action="click->rockridge--mc#close"></div>
           <div class="modal-content">
             Modal content goes here


### PR DESCRIPTION
This fixes the StimulusDataAttributes class within the Modal controller so that it will use the controller name argument for the actions.

It also adds two actions to the default Stimulus data attributes:
- an escape key listener to close the modal
- a command listener to open or close the modal